### PR TITLE
Add rayon parallel sort example

### DIFF
--- a/src/concurrency.md
+++ b/src/concurrency.md
@@ -3,6 +3,7 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Mutate the elements of an array in parallel][ex-rayon-iter-mut] | [![rayon-badge]][rayon] | [![cat-concurrency-badge]][cat-concurrency] |
+| [Sort a vector in parallel][ex-rayon-parallel-sort] | [![rayon-badge]][rayon] [![rand-badge]][rand] | [![cat-concurrency-badge]][cat-concurrency] |
 | [Spawn a short-lived thread][ex-crossbeam-spawn] | [![crossbeam-badge]][crossbeam] | [![cat-concurrency-badge]][cat-concurrency] |
 | [Draw fractal dispatching work to a thread pool][ex-threadpool-fractal] | [![threadpool-badge]][threadpool] [![num-badge]][num] [![num_cpus-badge]][num_cpus] [![image-badge]][image] | [![cat-concurrency-badge]][cat-concurrency][![cat-science-badge]][cat-science][![cat-rendering-badge]][cat-rendering] |
 
@@ -11,6 +12,10 @@
 ## Mutate the elements of an array in parallel
 
 [![rayon-badge]][rayon] [![cat-concurrency-badge]][cat-concurrency]
+
+The example uses the `rayon` crate, which is a data parallelism library for Rust.
+`rayon` provides the [`par_iter_mut`] method for any parallel iterable data type.
+It lets us write iterator-like chains that execute in parallel.
 
 ```rust
 extern crate rayon;
@@ -26,15 +31,57 @@ fn main() {
 }
 ```
 
-The example uses the Rayon crate, which is a data parallelism library for Rust.
-Rayon provides the `par_iter_mut()` method for any parallel iterable data type.
-It lets us write iterator-like chains that execute in parallel.
+[ex-rayon-parallel-sort]: #ex-rayon-parallel-sort
+<a name="ex-rayon-parallel-sort"></a>
+## Sort a vector in parallel
+
+[![rayon-badge]][rayon] [![rand-badge]][rand] [![cat-concurrency-badge]][cat-concurrency]
+
+This example will sort in parallel a vector of Strings.
+
+[1] We start by preallocating a vector of empty Strings, so we can mutate the information in parallel later,
+to populate the vector with random Strings.
+
+[2] `par_iter_mut().for_each` takes a closure and applies it in parallel on all the elements of the vector.<br/>
+[3] Inside the passed closure we modify the element in the vector with a 5 character-long String, random generated.
+
+[4] We have [`multiple options`] to sort an Iterable data type, we chose here to use [`par_sort_unstable`]
+because it is usually faster than [`stable sorting`] algorithms which `rayon` also supports.
+
+```rust
+extern crate rand;
+extern crate rayon;
+
+use rand::Rng;
+use rayon::prelude::*;
+
+fn main() {
+    // [1]
+    let mut vec = vec![String::new(); 100_000];
+
+    // [2]
+    vec.par_iter_mut().for_each(|p| {
+        // [3]
+        *p = rand::weak_rng().gen_ascii_chars().take(5).collect()
+    });
+
+    // [4]
+    vec.par_sort_unstable();
+}
+```
+
+
 
 [ex-crossbeam-spawn]: #ex-crossbeam-spawn
 <a name="ex-crossbeam-spawn"></a>
 ## Spawn a short-lived thread
 
 [![crossbeam-badge]][crossbeam] [![cat-concurrency-badge]][cat-concurrency]
+
+The example uses the `crossbeam` crate, which provides data structures and functions
+for concurrent and parallel programming. [`Scope::spawn`] spawns a new scoped thread that is guaranteed
+to terminate before returning from the closure that passed into [`crossbeam::scope`] function, meaning that
+you can reference data from the calling function.
 
 ```rust
 extern crate crossbeam;
@@ -64,20 +111,23 @@ fn find_max(arr: &[i32], start: usize, end: usize) -> i32 {
 }
 ```
 
-The example uses `crossbeam` crate, which provides data structures and functions
-for concurrent and parallel programming. [`Scope::spawn`] spawns a new scoped thread that is guaranteed
-to terminate before returning from the closure that passed into [`crossbeam::scope`] function, meaning that
-you can reference data from the calling function.
-
 [ex-threadpool-fractal]: #ex-threadpool-fractal
 <a name="ex-threadpool-fractal"></a>
 ## Draw fractal dispatching work to a thread pool
 
 [![threadpool-badge]][threadpool] [![num-badge]][num] [![num_cpus-badge]][num_cpus] [![image-badge]][image] [![cat-concurrency-badge]][cat-concurrency][![cat-science-badge]][cat-science][![cat-rendering-badge]][cat-rendering]
 
-Draws a fractal from [Julia set] to an image utilizing a thread pool for computation.
+This example draws a fractal from [Julia set] to an image utilizing a thread pool for computation.
 
 <a href="https://cloud.githubusercontent.com/assets/221000/26546700/9be34e80-446b-11e7-81dc-dd9871614ea1.png"><img src="https://cloud.githubusercontent.com/assets/221000/26546700/9be34e80-446b-11e7-81dc-dd9871614ea1.png" width="150" /></a>
+
+Firstly, the example allocates memory for output image of given width and height with [`ImageBuffer::new`]
+and pre-calculates all possible RGB pixel values using [`Rgb::from_channels`].
+Secondly, creates a new [`ThreadPool`] with thread count equal to number of
+logical cores in CPU obtained with [`num_cpus::get`].
+Subsequently, dispatches calculation to thread pool [`ThreadPool::execute`].
+
+Lastly, collects calculation results via [`mpsc::channel`] with [`Receiver::recv`], draws them with [`ImageBuffer::put_pixel`] and encodes the final image into `output.png` using [`ImageBuffer::save`].
 
 ```rust,no_run
 # #[macro_use]
@@ -182,14 +232,6 @@ fn run() -> Result<()> {
 # quick_main!(run);
 ```
 
-Firstly, the example allocates memory for output image of given width and height with [`ImageBuffer::new`]
-and pre-calculates all possible RGB pixel values using [`Rgb::from_channels`].
-Secondly, creates a new [`ThreadPool`] with thread count equal to number of
-logical cores in CPU obtained with [`num_cpus::get`].
-Subsequently, dispatches calculation to thread pool [`ThreadPool::execute`].
-
-Lastly, collects calculation results via [`mpsc::channel`] with [`Receiver::recv`], draws them with [`ImageBuffer::put_pixel`] and encodes the final image into `output.png` using [`ImageBuffer::save`].
-
 <!-- Categories -->
 
 [cat-concurrency-badge]: https://badge-cache.kominick.com/badge/concurrency--x.svg?style=social
@@ -209,6 +251,8 @@ Lastly, collects calculation results via [`mpsc::channel`] with [`Receiver::recv
 [num]: https://docs.rs/num/
 [num_cpus-badge]: https://badge-cache.kominick.com/crates/v/num_cpus.svg?label=num_cpus
 [num_cpus]: https://docs.rs/num_cpus/
+[rand-badge]: https://badge-cache.kominick.com/crates/v/rand.svg?label=rand
+[rand]: https://docs.rs/rand/
 [rayon-badge]: https://badge-cache.kominick.com/crates/v/rayon.svg?label=rayon
 [rayon]: https://docs.rs/rayon/
 [threadpool-badge]: https://badge-cache.kominick.com/crates/v/threadpool.svg?label=threadpool
@@ -223,8 +267,12 @@ Lastly, collects calculation results via [`mpsc::channel`] with [`Receiver::recv
 [`Receiver::recv`]: https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.recv
 [`Rgb::from_channels`]: https://docs.rs/image/*/image/struct.Rgb.html#method.from_channels
 [`Scope::spawn`]: https://docs.rs/crossbeam/0.*/crossbeam/struct.Scope.html#method.spawn
+[`stable sorting`]: https://docs.rs/rayon/*/rayon/slice/trait.ParallelSliceMut.html#method.par_sort
 [`ThreadPool::execute`]: https://docs.rs/threadpool/*/threadpool/struct.ThreadPool.html#method.execute
 [`ThreadPool`]: https://docs.rs/threadpool/*/threadpool/struct.ThreadPool.html
 [`crossbeam::scope`]: https://docs.rs/crossbeam/0.*/crossbeam/fn.scope.html
 [`mpsc::channel`]: https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html
+[`multiple options`]: https://docs.rs/rayon/*/rayon/slice/trait.ParallelSliceMut.html
 [`num_cpus::get`]: https://docs.rs/num_cpus/*/num_cpus/fn.get.html
+[`par_iter_mut`]: https://docs.rs/rayon/*/rayon/iter/trait.IntoParallelRefMutIterator.html#tymethod.par_iter_mut
+[`par_sort_unstable`]: https://docs.rs/rayon/*/rayon/slice/trait.ParallelSliceMut.html#method.par_sort_unstable

--- a/src/intro.md
+++ b/src/intro.md
@@ -59,6 +59,7 @@ community. It needs and welcomes help. For details see
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Mutate the elements of an array in parallel][ex-rayon-iter-mut] | [![rayon-badge]][rayon] | [![cat-concurrency-badge]][cat-concurrency] |
+| [Sort a vector in parallel][ex-rayon-parallel-sort] | [![rayon-badge]][rayon] [![rand-badge]][rand] | [![cat-concurrency-badge]][cat-concurrency] |
 | [Spawn a short-lived thread][ex-crossbeam-spawn] | [![crossbeam-badge]][crossbeam] | [![cat-concurrency-badge]][cat-concurrency] |
 | [Draw fractal dispatching work to a thread pool][ex-threadpool-fractal] | [![threadpool-badge]][threadpool] [![num-badge]][num] [![num_cpus-badge]][num_cpus] [![image-badge]][image] | [![cat-concurrency-badge]][cat-concurrency][![cat-science-badge]][cat-science][![cat-rendering-badge]][cat-rendering] |
 
@@ -278,6 +279,7 @@ Keep lines sorted.
 [ex-rand-range]: basics.html#ex-rand-range
 [ex-random-port-tcp]: net.html#ex-random-port-tcp
 [ex-rayon-iter-mut]: concurrency.html#ex-rayon-iter-mut
+[ex-rayon-parallel-sort]: concurrency.html#ex-rayon-parallel-sort
 [ex-regex-filter-log]: basics.html#ex-regex-filter-log
 [ex-rest-custom-params]: net.html#ex-rest-custom-params
 [ex-rest-get]: net.html#ex-rest-get


### PR DESCRIPTION
I initially went with an example like this:
```rust
extern crate rand;
extern crate rayon;

use rand::Rng;
use rayon::prelude::*;

fn main() {
    let mut vec = vec![0i64; 1_000_000];
    
    // Generating random numbers to be sorted later
    vec.par_iter_mut().for_each(|p| *p = rand::weak_rng().gen::<i64>());
    
    // Using Rayon's Parallel QuickSort to sort the vector
    vec.par_sort_unstable();
}
```
but that seemed overly simplistic(I think you are more likely to sort strings than just integers).

Had no idea what to write in the description, under the code...