### PR TITLE
Adds 'handle errors correctly in main' example.

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -12,6 +12,7 @@
 | [Declare lazily evaluated constant][ex-lazy-constant] | [![lazy_static-badge]][lazy_static] | [![cat-caching-badge]][cat-caching] [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Maintain global mutable state][ex-global-mut-state] | [![lazy_static-badge]][lazy_static] | [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Access a file randomly using a memory map][ex-random-file-access] | [![memmap-badge]][memmap] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Handle errors correctly in main][error-handling] | [![error-chain-badge]][error-chain] | [![cat-rust-patterns-badge]][cat-rust-patterns] |
 
 
 [ex-std-read-lines]: #ex-std-read-lines
@@ -411,6 +412,45 @@ fn run() -> Result<()> {
 # quick_main!(run);
 ```
 
+[error-handling]: #error-handling
+<a name="error-handling"></a>
+## Handle errors correctly in main
+
+[![error-chain-badge]][error-chain] [![cat-rust-patterns-badge]][cat-rust-patterns]
+
+Uses [error-chain] to handle error occurred when trying to open a file that does not exist.
+
+First, we call `error_chain!{}` inside a new module named  _errors_. This will create the default types `Error`, `ErrorKind`, `ResultExt` and ` Result`, and store them in `errors`. To be able to use these types we must call `use errors::*`.
+
+To handle the erros that may occur when calling `open_foo()`, it must have return type `Reuslt<()>`. We then use [`if let`] when calling it to detect if an error has occurred, and to handle it in an apropiated way.
+```rust
+#[macro_use]
+extern crate error_chain;
+
+mod errors {
+    error_chain!{}
+}
+
+use errors::*;
+
+fn main() {
+    if let Err(ref e) = open_foo() {
+        println!("error: {}", e);
+        for e in e.iter().skip(1) {
+            println!("caused by: {}", e);
+        }
+    }
+}
+
+fn open_foo() -> Result<()> {
+    use std::fs::File;
+    File::open("foo.txt")
+        .chain_err(|| "cannot open foo.txt")?;
+
+    Ok(())
+}
+```
+
 <!-- Categories -->
 
 [cat-caching-badge]: https://badge-cache.kominick.com/badge/caching--x.svg?style=social
@@ -425,6 +465,7 @@ fn run() -> Result<()> {
 [cat-os]: https://crates.io/categories/os
 [cat-rust-patterns-badge]: https://badge-cache.kominick.com/badge/rust_patterns--x.svg?style=social
 [cat-rust-patterns]: https://crates.io/categories/rust-patterns
+
 [cat-text-processing-badge]: https://badge-cache.kominick.com/badge/text_processing--x.svg?style=social
 [cat-text-processing]: https://crates.io/categories/text-processing
 
@@ -442,6 +483,8 @@ fn run() -> Result<()> {
 [regex-badge]: https://badge-cache.kominick.com/crates/v/regex.svg?label=regex
 [memmap]: https://docs.rs/memmap/
 [memmap-badge]: https://badge-cache.kominick.com/crates/v/memmap.svg?label=memmap
+[error-chain]: https://docs.rs/error-chain/0.10.0/error_chain/
+[error-chain-badge]: https://img.shields.io/crates/v/error-chain.svg?label=error-chain
 
 <!-- API links -->
 
@@ -466,6 +509,7 @@ fn run() -> Result<()> {
 [`MutexGuard`]: https://doc.rust-lang.org/std/sync/struct.MutexGuard.html
 [`Mmap::as_slice`]: https://docs.rs/memmap/*/memmap/struct.Mmap.html#method.as_slice
 [`seek`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.seek
+[`if let`]: https://doc.rust-lang.org/book/first-edition/if-let.html
 
 <!-- Reference -->
 

--- a/src/basics.md
+++ b/src/basics.md
@@ -418,11 +418,13 @@ fn run() -> Result<()> {
 
 [![error-chain-badge]][error-chain] [![cat-rust-patterns-badge]][cat-rust-patterns]
 
-Handles the error that occur when we try to open a file that does not exist. We do this using [error-chain], a library that takes care of a lot of boilerplate code that an user would have to write in order to handle erros in Rust. For more details please check the chapter [Error Handling] of TRPL.
+Handles error that occur when we try to open a file that does not exist. We do this using [error-chain], a library that takes care of a lot of boilerplate code needed in order to [handle errors in Rust].
 
-The [`error_chain!`] macro creates the types [`Error`], [`ErrorKind`], [`Result`] and [`ResultExt`]. Additionaly, we use `Io(sd::io::Error)` for automatic conversion between this error chain and other error types not defined by [`error_chain!`]. In this case, [`std::io::Error`]
+We call `Io(std::io::Error)` inside `foreign_links` to convert the type `std::io::Error` into error-chain's custom version of it.
 
-To handle the result of a function, in this case `open_foo`, that function must return a [`Result`]. When calling `open_foo`, we use pattern matching to print an error message if an error occur.
+To handle the result of a function that might return an error, in this example `open_foo`, it must return a `Result`. To handle that result, we use pattern matching on it when calling the function. In this example we print an error message if that result was an error.
+
+
 
 ```rust
 #[macro_use]
@@ -507,13 +509,8 @@ fn read_foo() -> Result<()> {
 [`Mmap::as_slice`]: https://docs.rs/memmap/*/memmap/struct.Mmap.html#method.as_slice
 [`seek`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.seek
 [`error_chain!`]: https://docs.rs/error-chain/*/error_chain/#declaring-error-types
-[`Error`]: https://docs.rs/error-chain/*/error_chain/example_generated/struct.Error.html
-[`ErrorKind`]: https://docs.rs/error-chain/*/error_chain/trait.ChainedError.html#associatedtype.ErrorKind
-[`Result`]: https://docs.rs/error-chain/*/error_chain/example_generated/type.Result.html
-[`ResultExt`]: https://docs.rs/error-chain/*/error_chain/example_generated/trait.ResultExt.html
-[`std::io::Error`]: https://doc.rust-lang.org/std/io/struct.Error.html
 
 <!-- Reference -->
 
 [race-condition-file]: https://en.wikipedia.org/wiki/Race_condition#File_systems
-[Error Handling]: https://doc.rust-lang.org/book/second-edition/ch09-00-error-handling.html
+[handle errors in Rust]: https://doc.rust-lang.org/book/second-edition/ch09-00-error-handling.html

--- a/src/intro.md
+++ b/src/intro.md
@@ -30,6 +30,7 @@ community. It needs and welcomes help. For details see
 | [Declare lazily evaluated constant][ex-lazy-constant] | [![lazy_static-badge]][lazy_static] | [![cat-caching-badge]][cat-caching] [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Maintain global mutable state][ex-global-mut-state] | [![lazy_static-badge]][lazy_static] | [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Access a file randomly using a memory map][ex-random-file-access] | [![memmap-badge]][memmap] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Handle errors correctly in main][error-handling] | [![error-chain-badge]][error-chain] | [![cat-rust-patterns-badge]][cat-rust-patterns]
 
 ## [Encoding](encoding.html)
 
@@ -203,6 +204,8 @@ Keep lines sorted.
 [walkdir]: https://docs.rs/walkdir/
 [memmap-badge]: https://badge-cache.kominick.com/crates/v/memmap.svg?label=memmap
 [memmap]: https://docs.rs/memmap/
+[error-chain]: https://docs.rs/error-chain/0.10.0/error_chain/
+[error-chain-badge]: https://img.shields.io/crates/v/error-chain.svg?label=error-chain
 
 <!-- Examples -->
 
@@ -257,3 +260,4 @@ Keep lines sorted.
 [ex-url-rm-frag]: net.html#ex-url-rm-frag
 [ex-urlencoded]: encoding.html#ex-urlencoded
 [ex-random-file-access]: basics.html#ex-random-file-access
+[error-handling]: basics.html#error-handling

--- a/src/intro.md
+++ b/src/intro.md
@@ -30,7 +30,7 @@ community. It needs and welcomes help. For details see
 | [Declare lazily evaluated constant][ex-lazy-constant] | [![lazy_static-badge]][lazy_static] | [![cat-caching-badge]][cat-caching] [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Maintain global mutable state][ex-global-mut-state] | [![lazy_static-badge]][lazy_static] | [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Access a file randomly using a memory map][ex-random-file-access] | [![memmap-badge]][memmap] | [![cat-filesystem-badge]][cat-filesystem] |
-| [Handle errors correctly in main][error-handling] | [![error-chain-badge]][error-chain] | [![cat-rust-patterns-badge]][cat-rust-patterns]
+| [Handle errors correctly in main][ex-simple-error-handling] | [![error-chain-badge]][error-chain] | [![cat-rust-patterns-badge]][cat-rust-patterns]
 
 ## [Encoding](encoding.html)
 
@@ -204,8 +204,8 @@ Keep lines sorted.
 [walkdir]: https://docs.rs/walkdir/
 [memmap-badge]: https://badge-cache.kominick.com/crates/v/memmap.svg?label=memmap
 [memmap]: https://docs.rs/memmap/
-[error-chain]: https://docs.rs/error-chain/0.10.0/error_chain/
-[error-chain-badge]: https://img.shields.io/crates/v/error-chain.svg?label=error-chain
+[error-chain]: https://docs.rs/error-chain/*/error_chain/
+[error-chain-badge]: https://badge-cache.kominick.com/crates/v/error-chain.svg?label=error-chain
 
 <!-- Examples -->
 
@@ -260,4 +260,4 @@ Keep lines sorted.
 [ex-url-rm-frag]: net.html#ex-url-rm-frag
 [ex-urlencoded]: encoding.html#ex-urlencoded
 [ex-random-file-access]: basics.html#ex-random-file-access
-[error-handling]: basics.html#error-handling
+[ex-simple-error-handling]: basics.html#ex-simple-error-handling


### PR DESCRIPTION
Issue #214

Note: This example has the category-badge **rust patterns** even though in crates.io error-chain does not belong to any category.