### PR TITLE
fixed links and CI auto-deploy after move to rust-lang-nursery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ contribute to. Help is welcome.
 To start, clone the cookbook from git and navigate to that directory:
 
 ```
-git clone https://github.com/brson/rust-cookbook.git
+git clone https://github.com/rust-lang-nursery/rust-cookbook.git
 cd rust-cookbook
 ```
 
@@ -82,9 +82,9 @@ Contribution will be open to a broader set of crates in the future.
 For more about which crates are represented in the cookbook, see ["a
 note about crate representation"][which-crates] in the cookbook.
 
-[example]: https://github.com/brson/rust-cookbook/issues?q=is%3Aissue+is%3Aopen+label%3Aexample
-[tracking issue]: https://github.com/brson/rust-cookbook/issues?q=is%3Aissue+is%3Aopen+label%3A%22tracking+issue%22
-[which-crates]: https://brson.github.io/rust-cookbook/about.html#a-note-about-crate-representation
+[example]: https://github.com/rust-lang-nursery/rust-cookbook/issues?q=is%3Aissue+is%3Aopen+label%3Aexample
+[tracking issue]: https://github.com/rust-lang-nursery/rust-cookbook/issues?q=is%3Aissue+is%3Aopen+label%3A%22tracking+issue%22
+[which-crates]: https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-crate-representation
 [libz blitz]: https://internals.rust-lang.org/t/rust-libz-blitz/5184
 
 ## Adding an example
@@ -100,7 +100,7 @@ Adding an example involves:
 
 The finished commit will look something like [this one].
 
-[this one]: https://github.com/brson/rust-cookbook/commit/e698443f2af08d3106d953c68c1977eba3c3526c
+[this one]: https://github.com/rust-lang-nursery/rust-cookbook/commit/e698443f2af08d3106d953c68c1977eba3c3526c
 
 Examples are presently organized in three ways:
 
@@ -121,7 +121,7 @@ but since the cookbook is so new, quite possibly not. Ask on thread.
 For most steps you can simply follow the lead of existing examples.
 The art comes in writing effective examples.
 
-["how to read this book"]: https://brson.github.io/rust-cookbook/about.html#how-to-read-this-book
+["how to read this book"]: https://rust-lang-nursery.github.io/rust-cookbook/about.html#how-to-read-this-book
 
 ## Example guidelines
 
@@ -162,7 +162,7 @@ supports the use case and might not be obvious to someone new. Say the
 minimum possible about aspects that don't directly support the use
 case. See ["basics"] for examples.
 
-["basics"]: https://brson.github.io/rust-cookbook/basics.html
+["basics"]: https://rust-lang-nursery.github.io/rust-cookbook/basics.html
 
 Hyperlink all references to APIs, either on doc.rust-lang.org/std or
 docs.rs, and style them as `code`.
@@ -171,4 +171,4 @@ Finally, this book is intended to also demonstrate the integration
 of crates that work well together. Super bonus points for examples
 that feature multiple crates sensibly.
 
-[errors]: https://brson.github.io/rust-cookbook/about.html#a-note-about-error-handling
+[errors]: https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # A Rust Cookbook &emsp; [![Build Status]][travis]
 
-[Build Status]: https://api.travis-ci.org/brson/rust-cookbook.svg?branch=master
-[travis]: https://travis-ci.org/brson/rust-cookbook
+[Build Status]: https://api.travis-ci.org/rust-lang-nursery/rust-cookbook.svg?branch=master
+[travis]: https://travis-ci.org/rust-lang-nursery/rust-cookbook
 
 **[Read it here]**.
 
@@ -12,7 +12,7 @@ using the crates of the Rust ecosystem.
 These examples are complete, and suitable for copying directly into
 new cargo projects. They are tested and guaranteed to work.
 
-[Read it here]: https://brson.github.io/rust-cookbook
+[Read it here]: https://rust-lang-nursery.github.io/rust-cookbook
 
 ## Contributing
 
@@ -22,7 +22,7 @@ community. It needs and welcomes help.
 
 For details see [CONTRIBUTING.md] on GitHub.
 
-[CONTRIBUTING.md]: https://github.com/brson/rust-cookbook/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/rust-lang-nursery/rust-cookbook/blob/master/CONTRIBUTING.md
 
 ## License
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -53,7 +53,7 @@ echo "Committing book directory to gh-pages branch"
 REV=$(git rev-parse --short HEAD)
 cd book
 git init
-git remote add upstream "https://$GH_TOKEN@github.com/brson/rust-cookbook.git"
+git remote add upstream "https://$GH_TOKEN@github.com/rust-lang-nursery/rust-cookbook.git"
 git config user.name "Rust Cookbook"
 git config user.email "cookbook@rust-lang.org"
 git add -A .

--- a/src/intro.md
+++ b/src/intro.md
@@ -14,7 +14,7 @@ contribute to, and an easy to way get involved with the Rust
 community. It needs and welcomes help. For details see
 [CONTRIBUTING.md].
 
-[CONTRIBUTING.md]: https://github.com/brson/rust-cookbook/blob/master/CONTRIBUTING.md
+[CONTRIBUTING.md]: https://github.com/rust-lang-nursery/rust-cookbook/blob/master/CONTRIBUTING.md
 
 ## [Basics](basics.html)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
 fn main() {
     println!("This program does nothing.");
-    println!("See documentation at https://github.com/brson/rust-cookbook");
+    println!("See documentation at https://github.com/rust-lang-nursery/rust-cookbook");
 }

--- a/src/net.md
+++ b/src/net.md
@@ -396,7 +396,7 @@ struct User {
 
 fn run() -> Result<()> {
     let request_url = format!("https://api.github.com/repos/{owner}/{repo}/stargazers",
-                              owner = "brson",
+                              owner = "rust-lang-nursery",
                               repo = "rust-cookbook");
     println!("{}", request_url);
     let mut response = reqwest::get(&request_url)?;

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -112,7 +112,7 @@
 
             // START - Rust Cookbook customization
             $("#edit-button").click(function(){
-                var editWindow = window.open("https://github.com/brson/rust-cookbook/edit/master/src/{{ path }}");
+                var editWindow = window.open("https://github.com/rust-lang-nursery/rust-cookbook/edit/master/src/{{ path }}");
             });
             // END - Rust Cookbook customization
         </script>


### PR DESCRIPTION
- fixed stargazers example broken due to repo move
- fixed edit functionality broken due to repo move

cc https://github.com/rust-lang-nursery/rust-cookbook/issues/258