### PR TITLE
Add example for parsing into chrono::DateTime

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -27,6 +27,7 @@
 | [Obtain backtrace of complex error scenarios][ex-error-chain-backtrace] | [![error-chain-badge]][error-chain] | [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Measure elapsed time][ex-measure-elapsed-time] | [![std-badge]][std] | [![cat-time-badge]][cat-time] |
 | [Display formatted date and time][ex-format-datetime] | [![chrono-badge]][chrono] | [![cat-date-and-time-badge]][cat-date-and-time] |
+| [Parse string into DateTime struct][ex-parse-datetime] | [![chrono-badge]][chrono] | [![cat-date-and-time-badge]][cat-date-and-time] |
 
 [ex-std-read-lines]: #ex-std-read-lines
 <a name="ex-std-read-lines"></a>
@@ -1242,6 +1243,60 @@ fn main() {
 }
 ```
 
+[ex-parse-datetime]: #ex-parse-datetime
+<a name="ex-parse-datetime"></a>
+## Parse string into DateTime struct
+[![chrono-badge]][chrono] [![cat-date-and-time-badge]][cat-date-and-time]
+
+Parses a [`DateTime`] struct from strings representing the well-known formats
+[RFC 2822], [RFC 3339], and a custom format, using
+[`DateTime::parse_from_rfc2822`], [`DateTime::parse_from_rfc3339`], and
+[`DateTime::parse_from_str`] respectively.
+
+Escape sequences that are available for the [`DateTime::parse_from_str`] can be
+found at [`chrono::format::strftime`]. Note that the [`DateTime::parse_from_str`]
+requires that such a DateTime struct must be creatable that it uniquely
+identifies a date and a time. For parsing dates and times without timezones use
+[`NaiveDate`], [`NaiveTime`], and [`NaiveDateTime`].
+
+```rust
+extern crate chrono;
+# #[macro_use]
+# extern crate error_chain;
+#
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+#
+# error_chain! {
+#     foreign_links {
+#         DateParse(chrono::format::ParseError);
+#     }
+# }
+
+fn run() -> Result<()> {
+    let rfc2822 = DateTime::parse_from_rfc2822("Tue, 1 Jul 2003 10:52:37 +0200")?;
+    println!("{}", rfc2822);
+
+    let rfc3339 = DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")?;
+    println!("{}", rfc3339);
+
+    let custom = DateTime::parse_from_str("5.8.1994 8:00 am +0000", "%d.%m.%Y %H:%M %P %z")?;
+    println!("{}", custom);
+
+    let time_only = NaiveTime::parse_from_str("23:56:04", "%H:%M:%S")?;
+    println!("{}", time_only);
+
+    let date_only = NaiveDate::parse_from_str("2015-09-05", "%Y-%m-%d")?;
+    println!("{}", date_only);
+
+    let no_timezone = NaiveDateTime::parse_from_str("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S")?;
+    println!("{}", no_timezone);
+
+    Ok(())
+}
+#
+# quick_main!(run);
+```
+
 {{#include links.md}}
 
 <!-- API Reference -->
@@ -1294,9 +1349,17 @@ fn main() {
 [`seek`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.seek
 [`Stdio::piped`]: https://doc.rust-lang.org/std/process/struct.Stdio.html
 [`Utc::now`]: https://docs.rs/chrono/*/chrono/offset/struct.Utc.html#method.now
+[`DateTime`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html
 [`DateTime::to_rfc2822`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html#method.to_rfc2822
 [`DateTime::to_rfc3339`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html#method.to_rfc3339
 [`DateTime::format`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html#method.format
+[`DateTime::parse_from_rfc2822`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html#method.parse_from_rfc2822
+[`DateTime::parse_from_rfc3339`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html#method.parse_from_rfc3339
+[`DateTime::parse_from_str`]: https://docs.rs/chrono/*/chrono/struct.DateTime.html#method.parse_from_str
+[`NaiveDate`]: https://docs.rs/chrono/*/chrono/naive/struct.NaiveDate.html
+[`NaiveTime`]: https://docs.rs/chrono/*/chrono/naive/struct.NaiveTime.html
+[`NaiveDateTime`]: https://docs.rs/chrono/*/chrono/naive/struct.NaiveDateTime.html
+[`chrono::format::strftime`]: https://docs.rs/chrono/*/chrono/format/strftime/index.html
 [rand-distributions]: https://doc.rust-lang.org/rand/rand/distributions/index.html
 [replacement string syntax]: https://docs.rs/regex/*/regex/struct.Regex.html#replacement-string-syntax
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -45,6 +45,7 @@ community. It needs and welcomes help. For details see
 | [Obtain backtrace of complex error scenarios][ex-error-chain-backtrace] | [![error-chain-badge]][error-chain] | [![cat-rust-patterns-badge]][cat-rust-patterns] |
 | [Measure elapsed time][ex-measure-elapsed-time] | [![std-badge]][std] | [![cat-time-badge]][cat-time] |
 | [Display formatted date and time][ex-format-datetime] | [![chrono-badge]][chrono] | [![cat-date-and-time-badge]][cat-date-and-time] |
+| [Parse string into DateTime struct][ex-parse-datetime] | [![chrono-badge]][chrono] | [![cat-date-and-time-badge]][cat-date-and-time] |
 
 ## [Encoding](encoding.html)
 
@@ -191,6 +192,7 @@ community. It needs and welcomes help. For details see
 [ex-log-stdout]: logging.html#ex-log-stdout
 [ex-invalid-csv]: encoding.html#ex-invalid-csv
 [ex-paginated-api]: net.html#ex-paginated-api
+[ex-parse-datetime]: basics.html#ex-parse-datetime
 [ex-parse-subprocess-output]: basics.html#ex-parse-subprocess-output
 [ex-parse-subprocess-input]: basics.html#ex-parse-subprocess-input
 [ex-pbkdf2]: basics.html#ex-pbkdf2


### PR DESCRIPTION
Add an example for parsing strings in different formats into chrono::DateTime structs.

See also: #324