### PR TITLE
Add a missing log4rs badge to intro

### DIFF
--- a/src/intro.md
+++ b/src/intro.md
@@ -134,7 +134,7 @@ community. It needs and welcomes help. For details see
 | [Use a custom environment variable to set up logging][ex-log-env-variable] | [![log-badge]][log] [![env_logger-badge]][env_logger] | [![cat-debugging-badge]][cat-debugging] |
 | [Include timestamp in log messages][ex-log-timestamp] | [![log-badge]][log] [![env_logger-badge]][env_logger] [![chrono-badge]][chrono] | [![cat-debugging-badge]][cat-debugging] |
 | [Log to the Unix syslog][ex-log-syslog] | [![log-badge]][log] [![syslog-badge]][syslog] | [![cat-debugging-badge]][cat-debugging] |
-| [Log messages to a custom location][ex-log-custom] | [![log-badge]][log] | [![cat-debugging-badge]][cat-debugging] |
+| [Log messages to a custom location][ex-log-custom] | [![log-badge]][log] [![log4rs-badge]][log4rs] | [![cat-debugging-badge]][cat-debugging] |
 
 ## [Build Time Tooling](build_tools.html)
 


### PR DESCRIPTION
The "Log messages to a custom location" item on the intro page had only
the `log` badge, but was missing the `log4rs` badge. The `log4rs` badge
was already present on the recipe.

--------------------------
### Things to check before submitting a PR

- [x] the tests are passing locally with `cargo test`
- [x] cookbook renders correctly in `mdbook serve -o`
- [x] commits are squashed into one and rebased to latest master
- [ ] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue once PR is merged
- [x] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version 
- [ ] code identifiers in description are in hyperlinked backticks 
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR
- [ ] drop a comment on https://github.com/rust-lang-nursery/rust-cookbook/issues/209 if you consent to repository being relicensed with [CC0 license](https://creativecommons.org/choose/zero/) :+1: 
