### PR TITLE
fix C++ linking example

### DIFF
--- a/src/build_tools.md
+++ b/src/build_tools.md
@@ -152,7 +152,7 @@ extern "C" {
     int multiply(int x, int y);
 }
 
-int multiply() {
+int multiply(int x, int y) {
     return x*y;
 }
 ```
@@ -161,7 +161,7 @@ int multiply() {
 
 ```rust,ignore
 extern {
-    fn multiply(x : i32, y : i32);
+    fn multiply(x : i32, y : i32) -> i32;
 }
 
 fn main(){


### PR DESCRIPTION
This is a trivial fix.

### Things to check before submitting a PR

- [x] the tests are passing locally with `cargo test`
- [x] cookbook renders correctly in `mdbook serve -o`
- [x] commits are squashed into one and rebased to latest master
- [x] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [x] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [x] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [x] code identifiers in description are in hyperlinked backticks 
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [x] check if CI is happy with your PR
- [x] drop a comment on https://github.com/rust-lang-nursery/rust-cookbook/issues/209 if you consent to repository being relicensed with [CC0 license](https://creativecommons.org/choose/zero/) :+1:  

Thank you for reading, you may now delete this text! Thank you! :smile:
