### PR TITLE
rephrase text pattern replacement example

### DIFF
--- a/src/basics.md
+++ b/src/basics.md
@@ -825,8 +825,8 @@ fn main() {
 
 [![regex-badge]][regex] [![lazy_static-badge]][lazy_static] [![cat-text-processing-badge]][cat-text-processing]
 
-Replaces all occurrences of the hyphenated British English date pattern `2013-01-15`
-with its equivalent slashed American English date pattern `01/15/2013`.
+Replaces all occurrences of the standard ISO 8601 *YYYY-MM-DD* date pattern
+with the equivalent American English date with slashes; for example `2013-01-15` becomes `01/15/2013`.
 
 The method [`Regex::replace_all`] replaces all occurrences of the whole regex. The
 `Replacer` trait helps to figure out the replacement string. This trait is implemented
@@ -844,17 +844,17 @@ use regex::Regex;
 
 fn reformat_dates(before: &str) -> Cow<str> {
     lazy_static! {
-        static ref ENGL_DATE_REGEX : Regex = Regex::new(
+        static ref ISO8601_DATE_REGEX : Regex = Regex::new(
             r"(?P<y>\d{4})-(?P<m>\d{2})-(?P<d>\d{2})"
             ).unwrap();
     }
-    ENGL_DATE_REGEX.replace_all(before, "$m/$d/$y")
+    ISO8601_DATE_REGEX.replace_all(before, "$m/$d/$y")
 }
 
 fn main() {
-    let before = "2012-03-14, 2013-01-01 and 2014-07-05";
+    let before = "2012-03-14, 2013-01-15 and 2014-07-05";
     let after = reformat_dates(before);
-    assert_eq!(after, "03/14/2012, 01/01/2013 and 07/05/2014");
+    assert_eq!(after, "03/14/2012, 01/15/2013 and 07/05/2014");
 }
 ```
 


### PR DESCRIPTION
The example **Replace all occurrences of one text pattern with another pattern** mentions a "British English date pattern" when it's using ISO 8601 dates. Change the explanation and a variable name. Also use the same date in code that's in the explanation Untested, sorry.

fixes #360
