### PR TITLE
Update github pull request template after CC0 licensing change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,13 +15,12 @@ No worries if anything in these lists is unclear. Just submit the PR and ask awa
 - [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
 - [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
 - [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
-- [ ] code identifiers in description are in hyperlinked backticks 
+- [ ] code identifiers in description are in hyperlinked backticks
 ```markdown
 [`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
 ```
 
 ### Things to do after submitting PR
 - [ ] check if CI is happy with your PR
-- [ ] drop a comment on https://github.com/rust-lang-nursery/rust-cookbook/issues/209 if you consent to repository being relicensed with [CC0 license](https://creativecommons.org/choose/zero/) :+1:  
 
 Thank you for reading, you may now delete this text! Thank you! :smile:


### PR DESCRIPTION
Removed checkbox for CC0 comments--they are no longer required.