### PR TITLE
added ansi_term example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ threadpool = "1.6"
 toml = "0.4"
 url = "1.6"
 walkdir = "2.0"
+ansi_term = "0.11.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 syslog = "4.0"

--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -11,6 +11,8 @@ Akshat
 akshat
 alisha
 AlphaNumeric
+ansi
+ansiterm
 ApiResponse
 apis
 APIs

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Sort a Vector](algorithms/sorting.md)
 - [Command Line](cli.md)
   - [Argument Parsing](cli/arguments.md)
+  - [ANSI Terminal](cli/ansi_terminal.md)
 - [Compression](compression.md)
   - [Working with Tarballs](compression/tar.md)
 - [Concurrency](concurrency.md)

--- a/src/cli.md
+++ b/src/cli.md
@@ -3,6 +3,9 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Parse command line arguments][ex-clap-basic] | [![clap-badge]][clap] | [![cat-command-line-badge]][cat-command-line] |
+| [ANSI Terminal][ex-ansi_term-basic] | [![ansi_term-badge]][ansi_term]| [![cat-command-line-badge]][cat-command-line] |
 
 [ex-clap-basic]: cli/arguments.html#parse-command-line-arguments
+[ex-ansiterm-basic]: cli/ansi_terminal.html#ansi-terminal
+
 {{#include links.md}}

--- a/src/cli.md
+++ b/src/cli.md
@@ -6,6 +6,6 @@
 | [ANSI Terminal][ex-ansi_term-basic] | [![ansi_term-badge]][ansi_term]| [![cat-command-line-badge]][cat-command-line] |
 
 [ex-clap-basic]: cli/arguments.html#parse-command-line-arguments
-[ex-ansiterm-basic]: cli/ansi_terminal.html#ansi-terminal
+[ex-ansi_term-basic]: cli/ansi_terminal.html#ansi-terminal
 
 {{#include links.md}}

--- a/src/cli/ansi_terminal.md
+++ b/src/cli/ansi_terminal.md
@@ -1,5 +1,0 @@
-# Terminal styling
-
-{{#include ansi_terminal/ansi_term-basic.md}}
-
-{{#include ../links.md}}

--- a/src/cli/ansi_terminal.md
+++ b/src/cli/ansi_terminal.md
@@ -1,0 +1,5 @@
+# Terminal styling
+
+{{#include ansi_terminal/ansi_term-basic.md}}
+
+{{#include ../links.md}}

--- a/src/cli/ansi_terminal.md
+++ b/src/cli/ansi_terminal.md
@@ -1,4 +1,4 @@
-# ANSI terminal output
+# ANSI Terminal
 
 {{#include ansi_terminal/ansi_term-basic.md}}
 

--- a/src/cli/ansi_terminal.md
+++ b/src/cli/ansi_terminal.md
@@ -1,0 +1,5 @@
+# ANSI terminal output
+
+{{#include ansi_terminal/ansi_term-basic.md}}
+
+{{#include ../links.md}}

--- a/src/cli/ansi_terminal/ansi_term-basic.md
+++ b/src/cli/ansi_terminal/ansi_term-basic.md
@@ -8,33 +8,56 @@ There are two main data structures in this crate that our code needs to be conce
 
 **Note:** British english uses *Colour* instead of *Color*, don't get confused
 
+### Printing colored text to the Terminal
+
 ```rust
 extern crate ansi_term;
 
 use ansi_term::Colour;
-use ansi_term::Style;
 
 fn main() {
     println!("This is {} in color, {} in color and {} in color",
              Colour::Red.paint("red"),
              Colour::Blue.paint("blue"),
              Colour::Green.paint("green"));
+}
 ```
+
+#### Another way to print colored text to Terminal
 The code can be reformatted such that it converts the [`ANSIString`] to a string as so any other `Display` value
 ```rust
-    // The above can also be done using
+extern crate ansi_term;
+
+use ansi_term::Colour;
+
+fn main() {
     let blue_string = Colour::Blue.paint("Blue").to_string();
     println!("This is {} color", blue_string);
+}
 ```
+
+### Bold text in Terminal
 For anything more complex than plain foreground colour changes, the code needs to construct `Style` objects themselves, rather than beginning with a `Colour`. It can be achieved by chaining methods based on a new `Style`, created with [`Style::new()`]
 ```rust
+extern crate ansi_term;
+
+use ansi_term::Style;
+
+fn main() {
     println!("{} and this is not",
              Style::new().bold().paint("This is Bold"));
+}
 ```
-
-`Bold` methods can also been implemented for `Colour` values, an can be done by giving `styles` a foreground colour without having to begin with an empty Style value
+### Bold and colored text in terminal
+`Bold` methods can also been implemented for `Colour` values, and can be done by giving `styles` a foreground colour without having to begin with an empty Style value
 
 ```rust
+extern crate ansi_term;
+
+use ansi_term::Colour;
+use ansi_term::Style;
+
+fn main(){
     println!("{}, {} and {}",
              Colour::Yellow.paint("This is colored"),
              Style::new().bold().paint("this is bold"),

--- a/src/cli/ansi_terminal/ansi_term-basic.md
+++ b/src/cli/ansi_terminal/ansi_term-basic.md
@@ -1,0 +1,39 @@
+## ANSI Terminal
+
+[![ansi_term-badge]][ansi_term] [![cat-command-line-badge]][cat-command-line]
+
+This program depicts the use of [ansi_term crate] and how it is used for controlling colours and formatting, such as blue bold text or yellow underlined text, on ANSI terminals.
+
+There are two main data structures in this crate that you need to be concerned with: ANSIString and Style. A Style holds stylistic information: colours, whether the text should be bold, or blinking, or whatever. There are also Colour variants that represent simple foreground colour styles. An ANSIString is a string paired with a Style.
+
+```rust
+extern crate ansi_term;
+
+// British english uses Colour instead of Color
+use ansi_term::Colour;
+use ansi_term::Style;
+
+fn main() {
+    println!("This is {} in color, {} in color and {} in color",
+             Colour::Red.paint("red"),
+             Colour::Blue.paint("blue"),
+             Colour::Green.paint("green"));
+
+    // The above can also be done using
+    let blue_string = Colour::Blue.paint("Blue").to_string();
+    println!("This is {} color", blue_string);
+
+    // Bold text in the terminal
+    println!("{} and this is not",
+             Style::new().bold().paint("This is Bold"));
+
+    // Bold and Color can also be combined
+    println!("{}, {} and {}",
+             Colour::Yellow.paint("This is colored"),
+             Style::new().bold().paint("this is bold"),
+             Colour::Yellow.bold().paint("this is bold and colored"));
+}
+```
+
+[documentation]: https://docs.rs/ansi_term/
+[ansi_term crate]: https://crates.io/crates/ansi_term

--- a/src/cli/ansi_terminal/ansi_term-basic.md
+++ b/src/cli/ansi_terminal/ansi_term-basic.md
@@ -4,12 +4,13 @@
 
 This program depicts the use of [`ansi_term` crate] and how it is used for controlling colours and formatting, such as blue bold text or yellow underlined text, on ANSI terminals.
 
-There are two main data structures in this crate that you need to be concerned with: ANSIString and Style. A Style holds stylistic information: colours, whether the text should be bold, or blinking, or whatever. There are also Colour variants that represent simple foreground colour styles. An ANSIString is a string paired with a Style.
+There are two main data structures in this crate that our code needs to be concerned with: [`ANSIString`] and [`Style`]. A [`Style`] holds stylistic information: colours, whether the text should be bold, or blinking, or whatever. There are also Colour variants that represent simple foreground colour styles. An [`ANSIString`] is a string paired with a [`Style`].
+
+**Note:** British english uses *Colour* instead of *Color*, don't get confused
 
 ```rust
 extern crate ansi_term;
 
-// British english uses Colour instead of Color
 use ansi_term::Colour;
 use ansi_term::Style;
 
@@ -18,16 +19,22 @@ fn main() {
              Colour::Red.paint("red"),
              Colour::Blue.paint("blue"),
              Colour::Green.paint("green"));
-
+```
+The code can be reformatted such that it converts the [`ANSIString`] to a string as so any other `Display` value
+```rust
     // The above can also be done using
     let blue_string = Colour::Blue.paint("Blue").to_string();
     println!("This is {} color", blue_string);
-
-    // Bold text in the terminal
+```
+For anything more complex than plain foreground colour changes, the code needs to construct `Style` objects themselves, rather than beginning with a `Colour`. It can be achieved by chaining methods based on a new `Style`, created with [`Style::new()`]
+```rust
     println!("{} and this is not",
              Style::new().bold().paint("This is Bold"));
+```
 
-    // Bold and Color can also be combined
+`Bold` methods can also been implemented for `Colour` values, an can be done by giving `styles` a foreground colour without having to begin with an empty Style value
+
+```rust
     println!("{}, {} and {}",
              Colour::Yellow.paint("This is colored"),
              Style::new().bold().paint("this is bold"),
@@ -37,3 +44,6 @@ fn main() {
 
 [documentation]: https://docs.rs/ansi_term/
 [`ansi_term` crate]: https://crates.io/crates/ansi_term
+[`ANSIString`]: https://docs.rs/ansi_term/*/ansi_term/type.ANSIString.html
+[`Style`]: https://docs.rs/ansi_term/*/ansi_term/struct.Style.html
+[`Style::new()`]: https://docs.rs/ansi_term/0.11.0/ansi_term/struct.Style.html#method.new

--- a/src/cli/ansi_terminal/ansi_term-basic.md
+++ b/src/cli/ansi_terminal/ansi_term-basic.md
@@ -2,7 +2,7 @@
 
 [![ansi_term-badge]][ansi_term] [![cat-command-line-badge]][cat-command-line]
 
-This program depicts the use of [ansi_term crate] and how it is used for controlling colours and formatting, such as blue bold text or yellow underlined text, on ANSI terminals.
+This program depicts the use of [`ansi_term` crate] and how it is used for controlling colours and formatting, such as blue bold text or yellow underlined text, on ANSI terminals.
 
 There are two main data structures in this crate that you need to be concerned with: ANSIString and Style. A Style holds stylistic information: colours, whether the text should be bold, or blinking, or whatever. There are also Colour variants that represent simple foreground colour styles. An ANSIString is a string paired with a Style.
 
@@ -36,4 +36,4 @@ fn main() {
 ```
 
 [documentation]: https://docs.rs/ansi_term/
-[ansi_term crate]: https://crates.io/crates/ansi_term
+[`ansi_term` crate]: https://crates.io/crates/ansi_term

--- a/src/cli/arguments.md
+++ b/src/cli/arguments.md
@@ -1,6 +1,5 @@
 # Clap basic
 
 {{#include arguments/clap-basic.md}}
-{{#include ansi_terminal/ansi_term-basic.md}}
 
 {{#include ../links.md}}

--- a/src/cli/arguments.md
+++ b/src/cli/arguments.md
@@ -1,5 +1,6 @@
 # Clap basic
 
 {{#include arguments/clap-basic.md}}
+{{#include ansi_terminal/ansi_term-basic.md}}
 
 {{#include ../links.md}}

--- a/src/cli/arguments.md
+++ b/src/cli/arguments.md
@@ -1,3 +1,5 @@
+# Clap basic
+
 {{#include arguments/clap-basic.md}}
 
 {{#include ../links.md}}

--- a/src/links.md
+++ b/src/links.md
@@ -48,6 +48,8 @@ Keep lines sorted.
 
 <!-- Crates -->
 
+[ansi_term-badge]: https://badge-cache.kominick.com/crates/v/base64.svg?label=ansi_term
+[ansi_term]: https://docs.rs/ansi_term/
 [base64-badge]: https://badge-cache.kominick.com/crates/v/base64.svg?label=base64
 [base64]: https://docs.rs/base64/
 [bitflags-badge]: https://badge-cache.kominick.com/crates/v/bitflags.svg?label=bitflags


### PR DESCRIPTION
fixes #438 

it fixes #438 but The link is not created in the mdbook 