### PR TITLE
Add ndarray badge and link

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -189,6 +189,7 @@ MyFlags
 NaiveDate
 NaiveDateTime
 NaiveTime
+ndarray
 nFun
 NotFound
 NulError

--- a/src/links.md
+++ b/src/links.md
@@ -88,6 +88,8 @@ Keep lines sorted.
 [memmap]: https://docs.rs/memmap/
 [mime-badge]: https://badge-cache.kominick.com/crates/v/csv.svg?label=mime
 [mime]: https://docs.rs/mime/
+[ndarray-badge]: https://badge-cache.kominick.com/crate/ndarray.svg?label=ndarray
+[ndarray]: https://docs.rs/ndarray
 [num-badge]: https://badge-cache.kominick.com/crates/v/num.svg?label=num
 [num]: https://docs.rs/num/
 [num_cpus-badge]: https://badge-cache.kominick.com/crates/v/num_cpus.svg?label=num_cpus


### PR DESCRIPTION
Seeing as we are adding a few `ndarray` recipes in #450 it makes sense to add the badge and link.