### PR TITLE
Add various simple matrix recipes

### DIFF
--- a/src/science/mathematics.md
+++ b/src/science/mathematics.md
@@ -4,6 +4,9 @@
 |--------|--------|------------|
 | [Vector Sum][vector-sum] | [![ndarray-badge]][ndarray] | [![cat-science-badge]][cat-science] |
 | [Vector Norm][vector-norm] | [![ndarray-badge]][ndarray] | [![cat-science-badge]][cat-science] |
+| [Adding matrices][add-matrices] | [![ndarray-badge]][ndarray] | [![cat-science-badge]][cat-science] |
+| [Multiplying matrices][multiply-matrices] | [![ndarray-badge]][ndarray] | [![cat-science-badge]][cat-science] |
+| [Multiply a scalar with a vector with a matrix][multiply-scalar-vector-matrix] | [![ndarray-badge]][ndarray] | [![cat-science-badge]][cat-science] |
 | [Calculating the side length of a triangle][side-length] | [![std-badge]][std] | [![cat-science-badge]][cat-science] |
 | [Verifying tan is equal to sin divided by cos][tan-sin-cos] | [![std-badge]][std] | [![cat-science-badge]][cat-science] |
 | [Distance between two points on the Earth][latitude-longitude] | [![std-badge]][std] | [![cat-science-badge]][cat-science] |
@@ -11,13 +14,16 @@
 | [Adding complex numbers][add-complex] | [![num-badge]][num] | [![cat-science-badge]][cat-science] |
 | [Mathematical functions on complex numbers][mathematical-functions] | [![num-badge]][num] | [![cat-science-badge]][cat-science] |
 
-[create-complex]: science/mathematics/complex_numbers.html#creating-complex-numbers
-[add-complex]: science/mathematics/complex_numbers.html#adding-complex-numbers
-[mathematical-functions]: science/mathematics/complex_numbers.html#mathematical-functions
 [vector-sum]: science/mathematics/linear_algebra.html#vector-sum
 [vector-norm]: science/mathematics/linear_algebra.html#vector-norm
+[add-matrices]: science/mathematics/linear_algebra.html#adding-matrices
+[multiply-matrices]: science/mathematics/linear_algebra.html#multiplying-matrices
+[multiply-scalar-vector-matrix]: science/mathematics/linear_algebra.html#multiply-a-scalar-with-a-vector-with-a-matrix
 [side-length]: science/mathematics/trigonometry.html#calculating-the-side-length-of-a-triangle
 [tan-sin-cos]: science/mathematics/trigonometry.html#verifying-tan-is-equal-to-sin-divided-by-cos
 [latitude-longitude]: science/mathematics/trigonometry.html#distance-between-two-points-on-the-earth
+[create-complex]: science/mathematics/complex_numbers.html#creating-complex-numbers
+[add-complex]: science/mathematics/complex_numbers.html#adding-complex-numbers
+[mathematical-functions]: science/mathematics/complex_numbers.html#mathematical-functions
 
 {{#include ../links.md}}

--- a/src/science/mathematics/linear_algebra.md
+++ b/src/science/mathematics/linear_algebra.md
@@ -2,5 +2,8 @@
 
 {{#include linear_algebra/vector-sum.md}}
 {{#include linear_algebra/vector-norm.md}}
+{{#include linear_algebra/add-matrices.md}}
+{{#include linear_algebra/multiply-matrices.md}}
+{{#include linear_algebra/multiply-scalar-vector-matrix.md}}
 
 {{#include ../../links.md}}

--- a/src/science/mathematics/linear_algebra/add-matrices.md
+++ b/src/science/mathematics/linear_algebra/add-matrices.md
@@ -1,0 +1,22 @@
+## Adding matrices
+[![ndarray-badge]][ndarray] [![cat-science-badge]][cat-science]
+
+Creates two matrices with [`ndarray::arr2`] and adds them together.
+
+```rust
+extern crate ndarray;
+
+use ndarray::arr2;
+
+fn main() {
+    let a = arr2(&[[1, 2, 3],
+                   [4, 5, 6]]);
+
+    let b = arr2(&[[6, 5, 4],
+                   [3, 2, 1]]);
+
+    println!("Sum: {}", a + b);
+}
+```
+
+[`ndarray::arr2`]: https://docs.rs/ndarray/*/ndarray/fn.arr2.html

--- a/src/science/mathematics/linear_algebra/multiply-matrices.md
+++ b/src/science/mathematics/linear_algebra/multiply-matrices.md
@@ -1,0 +1,24 @@
+## Multiplying matrices
+[![ndarray-badge]][ndarray] [![cat-science-badge]][cat-science]
+
+Creates two matrices with [`ndarray::arr2`] and performs matrix multiplication on them with [`ndarray::ArrayBase::dot`].
+
+```rust
+extern crate ndarray;
+
+use ndarray::arr2;
+
+fn main() {
+    let a = arr2(&[[1, 2, 3],
+                   [4, 5, 6]]);
+
+    let b = arr2(&[[6, 3],
+                   [5, 2],
+                   [4, 1]]);
+
+    println!("{}", a.dot(&b));
+}
+```
+
+[`ndarray::arr2`]: https://docs.rs/ndarray/*/ndarray/fn.arr2.html
+[`ndarray::ArrayBase::dot`]: https://docs.rs/ndarray/*/ndarray/struct.ArrayBase.html#method.dot-1

--- a/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
+++ b/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
@@ -1,7 +1,7 @@
 ## Multiply a scalar with a vector with a matrix
 [![ndarray-badge]][ndarray] [![cat-science-badge]][cat-science]
 
-Creates a vector with [`ndarray::arr1`] and a matrix with [`ndarray::arr2`]. First, a scalar is multiplied by the vector to get another vector. Then, we convert the vector to a column vector with [`ndarray::ArrayBase::reversed_axes`] and multiply the matrix by it get a new matrix.
+Creates a vector with [`ndarray::arr1`] and a matrix with [`ndarray::arr2`]. First, a scalar is multiplied by the vector to get another vector. Then, convert the vector to a column vector with [`ndarray::ArrayBase::reversed_axes`] and multiply the matrix by the column vector to calculate a new matrix.
 
 ```rust
 extern crate ndarray;

--- a/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
+++ b/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
@@ -1,0 +1,29 @@
+## Multiply a scalar with a vector with a matrix
+[![ndarray-badge]][ndarray] [![cat-science-badge]][cat-science]
+
+Creates a vector with [`ndarray::arr1`] and a matrix with [`ndarray::arr2`]. First, a scalar is multiplied by the vector to get another vector. Then, we convert the vector to a column vector with [`ndarray::ArrayBase::reversed_axes`] and multiply the matrix by it get a new matrix.
+
+```rust
+extern crate ndarray;
+
+use ndarray::{arr1, arr2, Array1};
+
+fn main() {
+    let scalar = 4;
+
+    let vector = arr1(&[1, 2, 3]);
+
+    let matrix = arr2(&[[4, 5, 6],
+                        [7, 8, 9]]);
+
+    let new_vector: Array1<_> = scalar * vector;
+    println!("{}", new_vector);
+
+    let new_matrix = matrix * new_vector.reversed_axes();
+    println!("{}", new_matrix);
+}
+```
+
+[`ndarray::arr1`]: https://docs.rs/ndarray/*/ndarray/fn.arr1.html
+[`ndarray::arr2`]: https://docs.rs/ndarray/*/ndarray/fn.arr2.html
+[`ndarray::ArrayBase::reversed_axes`]: https://docs.rs/ndarray/*/ndarray/struct.ArrayBase.html#method.reversed_axes


### PR DESCRIPTION
Part of #450 

I'm unsure as to how we want to organise these. #461 seems to use another `linear-algebra` crate, but I'm not sure this is necessary. Could we just put all the recipes in `science/mathematics/matrices.md`?