### PR TITLE
Fix multiply-scalar-vector-matrix recipe

### DIFF
--- a/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
+++ b/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
@@ -1,7 +1,15 @@
 ## Multiply a scalar with a vector with a matrix
 [![ndarray-badge]][ndarray] [![cat-science-badge]][cat-science]
 
-Creates a vector with [`ndarray::arr1`] and a matrix with [`ndarray::arr2`]. First, a scalar is multiplied by the vector to get another vector. Then, convert the vector to a column vector with [`ndarray::ArrayBase::reversed_axes`] and multiply the matrix by the column vector to calculate a new matrix.
+Creates a 1-D array (vector) with [`ndarray::arr1`] and a 2-D array (matrix)
+with [`ndarray::arr2`]. First, a scalar is multiplied by the vector to get
+another vector. Then, the matrix is multiplied by the new vector with [`dot`].
+([`dot`] performs matrix multiplication, while the `*` operator performs
+element-wise multiplication.) In `ndarray`, 1-D arrays can be interpreted as
+either row or column vectors depending on context. If representing the
+orientation of a vector is important, a 2-D array with one row or one column
+must be used instead. In this example, the vector is a 1-D array on the
+right-hand side, so [`dot`] handles it as a column vector.
 
 ```rust
 extern crate ndarray;
@@ -19,11 +27,11 @@ fn main() {
     let new_vector: Array1<_> = scalar * vector;
     println!("{}", new_vector);
 
-    let new_matrix = matrix * new_vector.reversed_axes();
+    let new_matrix = matrix.dot(&new_vector);
     println!("{}", new_matrix);
 }
 ```
 
+[`dot`]: https://docs.rs/ndarray/*/ndarray/struct.ArrayBase.html#method.dot
 [`ndarray::arr1`]: https://docs.rs/ndarray/*/ndarray/fn.arr1.html
 [`ndarray::arr2`]: https://docs.rs/ndarray/*/ndarray/fn.arr2.html
-[`ndarray::ArrayBase::reversed_axes`]: https://docs.rs/ndarray/*/ndarray/struct.ArrayBase.html#method.reversed_axes


### PR DESCRIPTION
The original version was incorrect about `ndarray`'s treatment of 1-D arrays as vectors, and it incorrectly indicated that `*` performed matrix multiplication.

`ndarray` decides whether a 1-D array is a row vector or column vector in matrix multiplication by whether it is on the left-hand side or right-hand side. (The behavior matches NumPy. If it's on the left-hand side, it's a row vector, while if it's on the right-hand side, it's a column vector.) The original version incorrectly indicated that calling `.reversed_axes()` on a 1-D array would make it into a column vector. In fact, calling `.reversed_axes()` on a 1-D array has no effect since a 1-D array has only 1 axis.

Matrix multiplication is performed with `.dot()`, not `*`. The `*` operator performs element-wise multiplication.