### PR TITLE
Fix link to dot method for 2-D arrays

### DIFF
--- a/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
+++ b/src/science/mathematics/linear_algebra/multiply-scalar-vector-matrix.md
@@ -3,13 +3,13 @@
 
 Creates a 1-D array (vector) with [`ndarray::arr1`] and a 2-D array (matrix)
 with [`ndarray::arr2`]. First, a scalar is multiplied by the vector to get
-another vector. Then, the matrix is multiplied by the new vector with [`dot`].
-([`dot`] performs matrix multiplication, while the `*` operator performs
-element-wise multiplication.) In `ndarray`, 1-D arrays can be interpreted as
-either row or column vectors depending on context. If representing the
-orientation of a vector is important, a 2-D array with one row or one column
-must be used instead. In this example, the vector is a 1-D array on the
-right-hand side, so [`dot`] handles it as a column vector.
+another vector. Then, the matrix is multiplied by the new vector with
+[`ndarray::Array2::dot`]. (`dot` performs matrix multiplication, while the `*`
+operator performs element-wise multiplication.) In `ndarray`, 1-D arrays can be
+interpreted as either row or column vectors depending on context. If
+representing the orientation of a vector is important, a 2-D array with one row
+or one column must be used instead. In this example, the vector is a 1-D array
+on the right-hand side, so `dot` handles it as a column vector.
 
 ```rust
 extern crate ndarray;
@@ -32,6 +32,6 @@ fn main() {
 }
 ```
 
-[`dot`]: https://docs.rs/ndarray/*/ndarray/struct.ArrayBase.html#method.dot
+[`ndarray::Array2::dot`]: https://docs.rs/ndarray/*/ndarray/struct.ArrayBase.html#method.dot-1
 [`ndarray::arr1`]: https://docs.rs/ndarray/*/ndarray/fn.arr1.html
 [`ndarray::arr2`]: https://docs.rs/ndarray/*/ndarray/fn.arr2.html


### PR DESCRIPTION
When I checked the new version online after #487 was merged, I noticed that I used the wrong URL. (I provided the URL for `dot` for 1-D arrays instead of 2-D arrays.) I'm really sorry for the trouble.

Note that this also changes the link name from `dot` to `ndarray::Array2::dot` to avoid conflicting with the `vector-norm.md` recipe. (I tried keeping the link name as `dot`, but when I served the book locally with `mdbook serve -o`, I noticed that the URL for `dot` in `vector-norm.md` overrode the URL for `dot` in `multiply-scalar-vector-matrix.md`.)