### PR TITLE
Fix swapped links in web client examples

### DIFF
--- a/src/web/clients.md
+++ b/src/web/clients.md
@@ -19,7 +19,7 @@
 [ex-paginated-api]: web/clients/apis.html#consume-a-paginated-restful-api
 [ex-handle-rate-limited-api]: web/clients/apis.html#handle-a-rate-limited-api
 [ex-url-download]: web/clients/download.html#download-a-file-to-a-temporary-directory
-[ex-progress-with-range]: web/clients/download.html#post-a-file-to-paste-rs
-[ex-file-post]: web/clients/download.html#make-a-partial-download-with-http-range-headers
+[ex-progress-with-range]: web/clients/download.html#make-a-partial-download-with-http-range-headers
+[ex-file-post]: web/clients/download.html#post-a-file-to-paste-rs
 
 {{#include ../links.md}}

--- a/src/web/clients/download/post-file.md
+++ b/src/web/clients/download/post-file.md
@@ -1,4 +1,4 @@
-## POST a file to paste-rs.
+## POST a file to paste-rs
 
 [![reqwest-badge]][reqwest] [![cat-net-badge]][cat-net]
 


### PR DESCRIPTION
Two link targets in the web client download examples have been swapped, revert them. And also remove a dot at the end of a heading in one of the examples.
