### PR TITLE
Correct referenced crate in percent-encode chapter

### DIFF
--- a/src/encoding/string/percent-encode.md
+++ b/src/encoding/string/percent-encode.md
@@ -3,7 +3,7 @@
 [![url-badge]][url] [![cat-encoding-badge]][cat-encoding]
 
 Encode an input string with [percent-encoding] using the [`utf8_percent_encode`]
-function from the `percent-encoding` crate. Then decode using the [`percent_decode`]
+function from the `url` crate. Then decode using the [`percent_decode`]
 function.
 
 ```rust


### PR DESCRIPTION
The source code uses the `url` crate not the `percent-encoding` crate.
This change makes the text consistent with the source code.
