### PR TITLE
Use provided struct in CSV tab delimiter example

### DIFF
--- a/src/encoding/csv/delimiter.md
+++ b/src/encoding/csv/delimiter.md
@@ -33,7 +33,7 @@ Mark\tMelbourne\t46
 Ashley\tZurich\t92";
 
     let mut reader = ReaderBuilder::new().delimiter(b'\t').from_reader(data.as_bytes());
-    for result in reader.records() {
+    for result in reader.deserialize::<Record>() {
         println!("{:?}", result?);
     }
 


### PR DESCRIPTION
The CSV encoding tab delimiter example has a struct to deserialize into.
However it wasn't used.

I've changed it to use the provided struct.
It may make more sense to remove it instead, as it isn't the point of
this example. If it turns out to be the preferred method in the pull
request process, I'll do so.