### PR TITLE
Fix SQLite example so it compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rayon = "1.0"
 regex = "1.0"
 reqwest = "0.9"
 ring = "0.13.0-alpha"
-rusqlite = { version = "0.14", features = ["chrono"] }
+rusqlite = { version = "0.16", features = ["chrono"] }
 same-file = "1.0"
 select = "0.4"
 semver = "0.9"

--- a/src/database/sqlite/initialization.md
+++ b/src/database/sqlite/initialization.md
@@ -10,7 +10,7 @@ Use the `rusqlite` crate to open SQLite databases. See
 ```rust,no_run
 extern crate rusqlite;
 
-use rusqlite::{Connection, Result};
+use rusqlite::{Connection, Result, NO_PARAMS};
 
 fn main() -> Result<()> {
     let conn = Connection::open("cats.db")?;
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
              id integer primary key,
              name text not null
          )",
-        &[],
+        NO_PARAMS,
     )?;
     conn.execute(
         "create table if not exists cats (
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
              date_of_birth datetime,
              color_id integer not null references cat_colors(id)
          )",
-        &[],
+        NO_PARAMS,
     )?;
 
     Ok(())


### PR DESCRIPTION
Previous version gave me
```
error[E0282]: type annotations needed
  --> src/main.rs:13:9
   |
13 |         &[],
   |         ^^^ cannot infer type

error: aborting due to previous error
```
on stable and nightly.