### PR TITLE
update to sqlite version syntax

### DIFF
--- a/src/database/sqlite/transactions.md
+++ b/src/database/sqlite/transactions.md
@@ -15,7 +15,7 @@ a duplicate color is made, the transaction rolls back.
 ```rust,no_run
 extern crate rusqlite;
 
-use rusqlite::{Connection, Result};
+use rusqlite::{Connection, Result, NO_PARAMS};
 
 fn main() -> Result<()> {
     let mut conn = Connection::open("cats.db")?;
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
 fn successful_tx(conn: &mut Connection) -> Result<()> {
     let tx = conn.transaction()?;
 
-    tx.execute("delete from cat_colors", &[])?;
+    tx.execute("delete from cat_colors", NO_PARAMS)?;
     tx.execute("insert into cat_colors (name) values (?1)", &[&"lavender"])?;
     tx.execute("insert into cat_colors (name) values (?1)", &[&"blue"])?;
 
@@ -41,7 +41,7 @@ fn successful_tx(conn: &mut Connection) -> Result<()> {
 fn rolled_back_tx(conn: &mut Connection) -> Result<()> {
     let tx = conn.transaction()?;
 
-    tx.execute("delete from cat_colors", &[])?;
+    tx.execute("delete from cat_colors", NO_PARAMS)?;
     tx.execute("insert into cat_colors (name) values (?1)", &[&"lavender"])?;
     tx.execute("insert into cat_colors (name) values (?1)", &[&"blue"])?;
     tx.execute("insert into cat_colors (name) values (?1)", &[&"lavender"])?;


### PR DESCRIPTION

error[E0282]: type annotations needed
  --> /tmp/rust-skeptic.RdMBHU9Ab9y6/test.rs:20:42
   |
20 |     tx.execute("delete from cat_colors", &[])?;
   |                                          ^^^ cannot infer type
error: aborting due to previous error
For more information about this error, try `rustc --explain E0282`.
test transactions_sect_using_transactions_line_15 ... FAILED