### PR TITLE
439 download gzip content

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -116,6 +116,7 @@ graphemes
 Graphemes
 GzDecoder
 GzEncoder
+gzip
 Hackerman
 Hardcoded
 hardcoded

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [ANSI Terminal](cli/ansi_terminal.md)
 - [Compression](compression.md)
   - [Working with Tarballs](compression/tar.md)
+  - [Working with gzip files](compression/gzip.md)
 - [Concurrency](concurrency.md)
   - [Explicit Threads](concurrency/threads.md)
   - [Data Parallelism](concurrency/parallel.md)

--- a/src/compression.md
+++ b/src/compression.md
@@ -5,9 +5,11 @@
 | [Decompress a tarball][ex-tar-decompress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 | [Compress a directory into a tarball][ex-tar-compress] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 | [Decompress a tarball while removing a prefix from the paths][ex-tar-strip-prefix] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
+| [Download and read a gzip file][ex-gzip-download] | [![flate2-badge]][flate2] [![tar-badge]][tar] | [![cat-compression-badge]][cat-compression] |
 
 [ex-tar-decompress]: compression/tar.html#decompress-a-tarball
 [ex-tar-compress]: compression/tar.html#compress-a-directory-into-tarball
 [ex-tar-strip-prefix]: compression/tar.html#decompress-a-tarball-while-removing-a-prefix-from-the-paths
+[ex-gzip-download]: compression/gzip.html#download-and-read-a-gzip-file
 
 {{#include links.md}}

--- a/src/compression/gzip.md
+++ b/src/compression/gzip.md
@@ -1,0 +1,5 @@
+# Working with gzip files
+
+{{#include gzip/gzip-download.md}}
+
+{{#include ../links.md}}

--- a/src/compression/gzip/gzip-download.md
+++ b/src/compression/gzip/gzip-download.md
@@ -1,0 +1,40 @@
+## Download and read a gzip file
+
+[![std-badge]][std] [![flate2-badge]][flate2] [![reqwest-badge]][reqwest] [![cat-compression-badge]][cat-compression]
+
+Download a sample `gzip` file and read it.
+
+```rust,no_run
+extern crate flate2;
+extern crate reqwest;
+
+use std::error;
+use std::io::{copy, Read};
+use flate2::bufread::GzDecoder;
+use reqwest::get;
+
+fn main() -> Result<(), Box<error::Error>> {
+
+    // Download an example of a compressed json file
+    let mut response = get("https://wiki.mozilla.org/images/f/ff/Example.json.gz")?;
+
+    // Store the downloaded file in a buffer
+    // Note: This consumes the body of `response`
+    let mut buf: Vec<u8> = Vec::new ();
+    copy (&mut response, &mut buf)?;
+
+    // Decode the downloaded file
+    let mut gz = GzDecoder::new (&buf [..]);
+    let mut json = String::new ();
+    gz.read_to_string(&mut json)?;
+
+    println!("{}", json);
+    
+    Ok (())
+}
+```
+
+[`Builder::append_dir_all`]: https://docs.rs/tar/*/tar/struct.Builder.html#method.append_dir_all
+[`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
+[`GzEncoder`]: https://docs.rs/flate2/*/flate2/write/struct.GzEncoder.html
+[`tar::Builder`]: https://docs.rs/tar/*/tar/struct.Builder.html

--- a/src/compression/gzip/gzip-download.md
+++ b/src/compression/gzip/gzip-download.md
@@ -33,8 +33,3 @@ fn main() -> Result<(), Box<error::Error>> {
     Ok (())
 }
 ```
-
-[`Builder::append_dir_all`]: https://docs.rs/tar/*/tar/struct.Builder.html#method.append_dir_all
-[`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
-[`GzEncoder`]: https://docs.rs/flate2/*/flate2/write/struct.GzEncoder.html
-[`tar::Builder`]: https://docs.rs/tar/*/tar/struct.Builder.html


### PR DESCRIPTION
fixes #439 

Note: This doesn't use the [recommended way of error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling) because `std::error::Error` doesn't implement the trait `std::convert::From<reqwest::Error>` and adding that implementation, in my opinion, would have cluttered the recipe too much.