### PR TITLE
Adds cargo clean to CI test script.

### DIFF
--- a/ci/test_script.sh
+++ b/ci/test_script.sh
@@ -46,6 +46,7 @@ if [[ "${CONTENT_TESTS:-}" == 1 ]]; then
     fi
 else
     echo "Testing code snippets"
+    cargo clean
     cargo build --verbose
     cargo test --verbose
 fi


### PR DESCRIPTION
This adds `cargo clean` to the test script run by TravisCI, which was motivated by [this](https://github.com/budziq/rust-skeptic/issues/111#issuecomment-539662466) comment.

I guess it doesn't hurt adding this, but it doesn't seem to solve the issue for me locally.