### PR TITLE
Fix issue #573 - hmac example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rand = "0.6"
 rayon = "1.0"
 regex = "1.0"
 reqwest = "0.9"
-ring = "0.13.0-alpha"
+ring = "0.16.11"
 rusqlite = { version = "0.16", features = ["chrono"] }
 same-file = "1.0"
 select = "0.4"

--- a/src/concurrency/thread/threadpool-walk.md
+++ b/src/concurrency/thread/threadpool-walk.md
@@ -1,12 +1,12 @@
-## Calculate SHA1 sum of iso files concurrently
+## Calculate SHA256 sum of iso files concurrently
 
 [![threadpool-badge]][threadpool] [![num_cpus-badge]][num_cpus] [![walkdir-badge]][walkdir] [![ring-badge]][ring] [![cat-concurrency-badge]][cat-concurrency][![cat-filesystem-badge]][cat-filesystem]
 
-This example calculates the SHA1 for every file with iso extension in the
+This example calculates the SHA256 for every file with iso extension in the
 current directory. A threadpool generates threads equal to the number of cores
 present in the system found with [`num_cpus::get`].  [`Walkdir::new`] iterates
 the current directory and calls [`execute`] to perform the operations of reading
-and computing SHA1 hash.
+and computing SHA256 hash.
 
 ```rust,no_run
 extern crate walkdir;

--- a/src/concurrency/thread/threadpool-walk.md
+++ b/src/concurrency/thread/threadpool-walk.md
@@ -20,7 +20,7 @@ use std::io::{BufReader, Read, Error};
 use std::path::Path;
 use threadpool::ThreadPool;
 use std::sync::mpsc::channel;
-use ring::digest::{Context, Digest, SHA1};
+use ring::digest::{Context, Digest, SHA256};
 
 # // Verify the iso extension
 # fn is_iso(entry: &Path) -> bool {
@@ -32,7 +32,7 @@ use ring::digest::{Context, Digest, SHA1};
 
 fn compute_digest<P: AsRef<Path>>(filepath: P) -> Result<(Digest, P), Error> {
     let mut buf_reader = BufReader::new(File::open(&filepath)?);
-    let mut context = Context::new(&SHA1);
+    let mut context = Context::new(&SHA256);
     let mut buffer = [0; 1024];
 
     loop {

--- a/src/cryptography/hashing/hmac.md
+++ b/src/cryptography/hashing/hmac.md
@@ -7,7 +7,7 @@ Uses [`ring::hmac`] to creates a [`hmac::Signature`] of a string then verifies t
 ```rust
 extern crate ring;
 
-use ring::{digest, hmac, rand};
+use ring::{hmac, rand};
 use ring::rand::SecureRandom;
 use ring::error::Unspecified;
 
@@ -15,11 +15,11 @@ fn main() -> Result<(), Unspecified> {
     let mut key_value = [0u8; 48];
     let rng = rand::SystemRandom::new();
     rng.fill(&mut key_value)?;
-    let key = hmac::SigningKey::new(&digest::SHA256, &key_value);
+    let key = hmac::Key::new(hmac::HMAC_SHA256, &key_value);
 
     let message = "Legitimate and important message.";
     let signature = hmac::sign(&key, message.as_bytes());
-    hmac::verify_with_own_key(&key, message.as_bytes(), signature.as_ref())?;
+    hmac::verify(&key, message.as_bytes(), signature.as_ref())?;
 
     Ok(())
 }

--- a/src/cryptography/hashing/hmac.md
+++ b/src/cryptography/hashing/hmac.md
@@ -5,11 +5,8 @@
 Uses [`ring::hmac`] to creates a [`hmac::Signature`] of a string then verifies the signature is correct.
 
 ```rust
-<<<<<<< HEAD
 extern crate ring;
 
-=======
->>>>>>> c0369829c40380530088844be065c5e2ba4e2308
 use ring::{hmac, rand};
 use ring::rand::SecureRandom;
 use ring::error::Unspecified;


### PR DESCRIPTION
fixes issue #573 

Questions/concerns:
Section does not pass test under cargo test, but runs fine locally, on Rust playground, and under 'mdbook serve' on localhost.  It appears testing may refer to an older version of the ring crate.  Which version of ring does 'cargo test' call?

