### PR TITLE
bump up 'rusqlite' to fix failing test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rayon = "1.0"
 regex = "1.0"
 reqwest = "0.9"
 ring = "0.16.11"
-rusqlite = { version = "0.16", features = ["chrono"] }
+rusqlite = { version = "0.22", features = ["chrono"] }
 same-file = "1.0"
 select = "0.4"
 semver = "0.9"


### PR DESCRIPTION
## Fixes failing test code in 'database/sqlite/insert_select.md'
fixes the test case **'insert_select_sect_insert_and_select_data_line_8'** which is causing CI to fail.

## Before Fix : 
```
error[E0282]: type annotations needed for `rusqlite::MappedRows<'_, [closure@C:\Users\LONELY~1\AppData\Local\Temp\rust-skeptic.QY792HCVQQOx\test.rs:41:42: 46:6]>`
  --> C:\Users\LONELY~1\AppData\Local\Temp\rust-skeptic.QY792HCVQQOx\test.rs:42:9
   |
41 |     let cats = stmt.query_map(NO_PARAMS, |row| {
   |         ---- consider giving `cats` the explicit type `rusqlite::MappedRows<'_, [closure@C:\Users\LONELY~1\AppData\Local\Temp\rust-skeptic.QY792HCVQQOx\test.rs:41:42: 46:6]>`, where the type parameter `E` is specified
42 |         Ok(Cat {
   |         ^^ cannot infer type for type parameter `E` declared on the enum `Result`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0282`.
test insert_select_sect_insert_and_select_data_line_8 ... FAILED
```

## After Fix :
the test case no longer fails, and `cargo test` finishes successfully.