### PR TITLE
demonstrate basic http authentication

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -65,3 +65,4 @@
     - [Making Requests](web/clients/requests.md)
     - [Calling a Web API](web/clients/apis.md)
     - [Downloads](web/clients/download.md)
+    - [Web Authentication](web/clients/authentication.md)

--- a/src/web.md
+++ b/src/web.md
@@ -39,6 +39,12 @@
 | [Make a partial download with HTTP range headers][ex-progress-with-range] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [POST a file to paste-rs][ex-file-post] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 
+## Web Authentication
+
+| Recipe | Crates | Categories |
+|--------|--------|------------|
+| [Basic Authentication][ex-basic-authentication] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
+
 [ex-extract-links-webpage]: web/scraping.html#extract-all-links-from-a-webpage-html
 [ex-check-broken-links]: web/scraping.html#check-a-webpage-for-broken-links
 [ex-extract-mediawiki-links]: web/scraping.html#extract-all-unique-links-from-a-mediawiki-markup
@@ -63,5 +69,7 @@
 [ex-url-download]: web/clients/download.html#download-a-file-to-a-temporary-directory
 [ex-progress-with-range]: web/clients/download.html#make-a-partial-download-with-http-range-headers
 [ex-file-post]: web/clients/download.html#post-a-file-to-paste-rs
+
+[ex-basic-authentication]: web/clients/authentication.html#basic-authentication
 
 {{#include links.md}}

--- a/src/web/clients/authentication.md
+++ b/src/web/clients/authentication.md
@@ -1,0 +1,5 @@
+# Authentication
+
+{{#include authentication/basic.md}}
+
+{{#include ../../links.md}}

--- a/src/web/clients/authentication/basic.md
+++ b/src/web/clients/authentication/basic.md
@@ -1,0 +1,28 @@
+## Basic Authentication
+
+[![reqwest-badge]][reqwest] [![cat-net-badge]][cat-net]
+
+Uses [`reqwest::RequestBuilder::basic_auth`] to perform a basic HTTP authentication.
+
+```rust,edition2018,no_run
+use reqwest::blocking::Client;
+use reqwest::Error;
+
+fn main() -> Result<(), Error> {
+    let client = Client::new();
+
+    let user_name = "testuser".to_string();
+    let password: Option<String> = None;
+
+    let response = client
+        .get("https://httpbin.org/")
+        .basic_auth(user_name, password)
+        .send();
+
+    println!("{:?}", response);
+
+    Ok(())
+}
+```
+
+[`reqwest::RequestBuilder::basic_auth`]: https://docs.rs/reqwest/*/reqwest/struct.RequestBuilder.html#method.basic_auth


### PR DESCRIPTION
Part of #436 

Perform a basic HTTP authentication with `reqwest`'s blocking client.

If you'd prefer to use an asynchronous client instead, just say the word. (Personally, I don't have a strong preference for the sake of this example in either direction. But ultimately opted to go with the synchronous client to minimize the complexity of this example and purely focus it on the authentication aspect.)