### PR TITLE
596 headers

### DIFF
--- a/src/web.md
+++ b/src/web.md
@@ -31,6 +31,7 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Make a HTTP GET request][ex-url-basic] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
+| [Set custom headers and URL parameters for a REST request][ex-url-header] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [Query the GitHub API][ex-rest-get] | [![reqwest-badge]][reqwest] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding] |
 | [Check if an API resource exists][ex-rest-head] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [Create and delete Gist with GitHub API][ex-rest-post] | [![reqwest-badge]][reqwest] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding] |
@@ -54,6 +55,7 @@
 [ex-http-response-mime-type]: web/mime.html#parse-the-mime-type-of-a-http-response
 
 [ex-url-basic]: web/clients/requests.html#make-a-http-get-request
+[ex-url-header]: web/clients/requests.html#set-custom-headers-and-url-parameters-for-a-rest-request
 [ex-rest-custom-params]: web/clients/requests.html#set-custom-headers-and-url-parameters-for-a-rest-request
 [ex-rest-get]: web/clients/apis.html#query-the-github-api
 [ex-rest-head]: web/clients/apis.html#check-if-an-api-resource-exists

--- a/src/web/clients.md
+++ b/src/web/clients.md
@@ -3,6 +3,7 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Make a HTTP GET request][ex-url-basic] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
+| [Set custom headers and URL parameters for a REST request][ex-url-header] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [Query the GitHub API][ex-rest-get] | [![reqwest-badge]][reqwest] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding] |
 | [Check if an API resource exists][ex-rest-head] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 | [Create and delete Gist with GitHub API][ex-rest-post] | [![reqwest-badge]][reqwest] [![serde-badge]][serde] | [![cat-net-badge]][cat-net] [![cat-encoding-badge]][cat-encoding] |
@@ -12,6 +13,7 @@
 | [POST a file to paste-rs][ex-file-post] | [![reqwest-badge]][reqwest] | [![cat-net-badge]][cat-net] |
 
 [ex-url-basic]: clients/requests.html#make-a-http-get-request
+[ex-url-header]: web/clients/requests.html#set-custom-headers-and-url-parameters-for-a-rest-request
 [ex-rest-custom-params]: clients/requests.html#set-custom-headers-and-url-parameters-for-a-rest-request
 [ex-rest-get]: clients/apis.html#query-the-github-api
 [ex-rest-head]: clients/apis.html#check-if-an-api-resource-exists

--- a/src/web/clients/requests.md
+++ b/src/web/clients/requests.md
@@ -2,4 +2,6 @@
 
 {{#include requests/get.md}}
 
+{{#include requests/header.md}}
+
 {{#include ../../links.md}}


### PR DESCRIPTION
I've made a few changed to the original recipe:

- made the usage of `error_chain` visible to account for #563 
- switch to the synchronous reqwest client to simplify the recipe
- removed the authorization header since this is now handled via [reqwest::RequestBuilder::bearer_auth](https://docs.rs/reqwest/0.10.6/reqwest/blocking/struct.RequestBuilder.html#method.bearer_auth)
- got rid of the `hyper::header!` macro
- gave the `X-Powered-By` header a more generic/sterile value
- added missing links

fixes #596