### PR TITLE
Add escape characters in percent-encoding example

### DIFF
--- a/src/encoding/string/percent-encode.md
+++ b/src/encoding/string/percent-encode.md
@@ -11,7 +11,14 @@ use percent_encoding::{utf8_percent_encode, percent_decode, AsciiSet, CONTROLS};
 use std::str::Utf8Error;
 
 /// https://url.spec.whatwg.org/#fragment-percent-encode-set
-const FRAGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`');
+const FRAGMENT: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'`')
+    .add(b'+')
+    .add(b'%');
 
 fn main() -> Result<(), Utf8Error> {
     let input = "confident, productive systems programming";


### PR DESCRIPTION
### Description

Hi!

I found the characters `+` and `%` are alse should be escaped when followed [the section about percent-encoding](https://rust-lang-nursery.github.io/rust-cookbook/encoding/strings.html#percent-encode-a-string). So I try to fix it.

### Things to check before submitting a PR

- [x] the tests are passing locally with `cargo test`
- [x] cookbook renders correctly in `mdbook serve -o`
- [x] commits are squashed into one and rebased to latest master
- [x] spell check runs without errors `./ci/spellcheck.sh`
- [x] link check runs without errors `link-checker ./book`
- [x] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [x] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [x] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [x] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR
