### PR TITLE
Fix percent-encoding link

### DIFF
--- a/src/encoding/string/percent-encode.md
+++ b/src/encoding/string/percent-encode.md
@@ -2,9 +2,9 @@
 
 [![percent-encoding-badge]][percent-encoding] [![cat-encoding-badge]][cat-encoding]
 
-Encode an input string with [percent-encoding] using the [`utf8_percent_encode`]
-function from the `percent-encoding` crate. Then decode using the [`percent_decode`]
-function.
+Encode an input string with [percent-encoding][percent-encoding-wiki] using the
+[`utf8_percent_encode`] function from the `percent-encoding` crate. Then decode
+using the [`percent_decode`] function.
 
 ```rust,edition2018
 use percent_encoding::{utf8_percent_encode, percent_decode, AsciiSet, CONTROLS};
@@ -38,4 +38,5 @@ a `String`.
 [`percent_decode`]: https://docs.rs/percent-encoding/*/percent_encoding/fn.percent_decode.html
 [`utf8_percent_encode`]: https://docs.rs/percent-encoding/*/percent_encoding/fn.utf8_percent_encode.html
 
-[percent-encoding]: https://en.wikipedia.org/wiki/Percent-encoding
+[percent-encoding]: https://docs.rs/percent-encoding/
+[percent-encoding-wiki]: https://en.wikipedia.org/wiki/Percent-encoding


### PR DESCRIPTION
### Things to check before submitting a PR

- [X] the tests are passing locally with `cargo test`
- [x] cookbook renders correctly in `mdbook serve -o`
- [X] commits are squashed into one and rebased to latest master
- [ ] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
    -  if issue does not exist consider creating it or remove the clause
- [ ] spell check runs without errors `./ci/spellcheck.sh`
- [ ] link check runs without errors `link-checker ./book`
- [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [ ] code identifiers in description are in hyperlinked backticks

### Things to do after submitting PR
- [ ] check if CI is happy with your PR
