### PR TITLE
fix links in science/mathematics.md

### DIFF
--- a/src/science/mathematics.md
+++ b/src/science/mathematics.md
@@ -17,19 +17,19 @@
 | [Computing standard deviation][ex-standard-deviation] | [![std-badge]][std] | [![cat-science-badge]][cat-science] |
 | [Big integers][big-integers] | [![num-badge]][num] | [![cat-science-badge]][cat-science] |
 
-[vector-norm]: science/mathematics/linear_algebra.html#vector-norm
-[add-matrices]: science/mathematics/linear_algebra.html#adding-matrices
-[multiply-matrices]: science/mathematics/linear_algebra.html#multiplying-matrices
-[multiply-scalar-vector-matrix]: science/mathematics/linear_algebra.html#multiply-a-scalar-with-a-vector-with-a-matrix
-[invert-matrix]: science/mathematics/linear_algebra.html#invert-matrix
-[side-length]: science/mathematics/trigonometry.html#calculating-the-side-length-of-a-triangle
-[tan-sin-cos]: science/mathematics/trigonometry.html#verifying-tan-is-equal-to-sin-divided-by-cos
-[latitude-longitude]: science/mathematics/trigonometry.html#distance-between-two-points-on-the-earth
-[create-complex]: science/mathematics/complex_numbers.html#creating-complex-numbers
-[add-complex]: science/mathematics/complex_numbers.html#adding-complex-numbers
-[mathematical-functions]: science/mathematics/complex_numbers.html#mathematical-functions
-[ex-central-tendency]: science/mathematics/statistics.html#measures-of-central-tendency
-[ex-standard-deviation]: science/mathematics/statistics.html#standard-deviation
-[big-integers]: science/mathematics/miscellaneous.html#big-integers
+[vector-norm]: mathematics/linear_algebra.html#vector-norm
+[add-matrices]: mathematics/linear_algebra.html#adding-matrices
+[multiply-matrices]: mathematics/linear_algebra.html#multiplying-matrices
+[multiply-scalar-vector-matrix]: mathematics/linear_algebra.html#multiply-a-scalar-with-a-vector-with-a-matrix
+[invert-matrix]: mathematics/linear_algebra.html#invert-matrix
+[side-length]: mathematics/trigonometry.html#calculating-the-side-length-of-a-triangle
+[tan-sin-cos]: mathematics/trigonometry.html#verifying-tan-is-equal-to-sin-divided-by-cos
+[latitude-longitude]: mathematics/trigonometry.html#distance-between-two-points-on-the-earth
+[create-complex]: mathematics/complex_numbers.html#creating-complex-numbers
+[add-complex]: mathematics/complex_numbers.html#adding-complex-numbers
+[mathematical-functions]: mathematics/complex_numbers.html#mathematical-functions
+[ex-central-tendency]: mathematics/statistics.html#measures-of-central-tendency
+[ex-standard-deviation]: mathematics/statistics.html#standard-deviation
+[big-integers]: mathematics/miscellaneous.html#big-integers
 
 {{#include ../links.md}}


### PR DESCRIPTION
fixes broken links in : [https://rust-lang-nursery.github.io/rust-cookbook/science/mathematics.html](https://rust-lang-nursery.github.io/rust-cookbook/science/mathematics.html)

When going to a recipe from there:

## Before
https://rust-lang-nursery.github.io/rust-cookbook/science/science/mathematics/linear_algebra.html#vector-norm

## After
https://rust-lang-nursery.github.io/rust-cookbook/science/mathematics/linear_algebra.html#vector-norm