### PR TITLE
fix random range generator gen_range call

### DIFF
--- a/src/algorithms/randomness/rand-range.md
+++ b/src/algorithms/randomness/rand-range.md
@@ -9,8 +9,8 @@ use rand::Rng;
 
 fn main() {
     let mut rng = rand::thread_rng();
-    println!("Integer: {}", rng.gen_range(0, 10));
-    println!("Float: {}", rng.gen_range(0.0, 10.0));
+    println!("Integer: {}", rng.gen_range(0..10));
+    println!("Float: {}", rng.gen_range(0.0..10.0));
 }
 ```
 


### PR DESCRIPTION
fixes issue with `gen_range` call using `rand` crate 0.8.0, with API changes, `gen_range` argument should be a range.
