### PR TITLE
Changed to use inclusive range

### DIFF
--- a/src/science/mathematics/miscellaneous/big-integers.md
+++ b/src/science/mathematics/miscellaneous/big-integers.md
@@ -9,7 +9,7 @@ use num::bigint::{BigInt, ToBigInt};
 
 fn factorial(x: i32) -> BigInt {
     if let Some(mut factorial) = 1.to_bigint() {
-        for i in 1..(x+1) {
+        for i in 1..=x {
             factorial = factorial * i;
         }
         factorial


### PR DESCRIPTION
Used the factorial example as a reference in a Stack Overflow [answer] yesterday. Thought I'd just quickly update it to use an inclusive range instead.

[answer]: https://stackoverflow.com/a/65561835/2470818
