### PR TITLE
Fix internal link in concurrency/thread/crossbeam-spsc.md

### DIFF
--- a/src/concurrency/thread/crossbeam-spsc.md
+++ b/src/concurrency/thread/crossbeam-spsc.md
@@ -33,7 +33,7 @@ fn main() {
 ```
 
 [crossbeam-channel]: https://docs.rs/crate/crossbeam-channel/
-[ex-crossbeam-spawn]: concurrency/threads.html#spawn-a-short-lived-thread
+[ex-crossbeam-spawn]: #spawn-a-short-lived-thread
 [`crossbeam::scope`]: https://docs.rs/crossbeam/*/crossbeam/fn.scope.html
 [`Scope::spawn`]: https://docs.rs/crossbeam/*/crossbeam/thread/struct.Scope.html#method.spawn
 [`crossbeam_channel::unbounded`]: https://docs.rs/crossbeam-channel/*/crossbeam_channel/fn.unbounded.html


### PR DESCRIPTION
Currently, it results in linking to
https://rust-lang-nursery.github.io/rust-cookbook/concurrency/concurrency/threads.html
which is a 404.