### PR TITLE
fix incorrect badge link

### DIFF
--- a/src/links.md
+++ b/src/links.md
@@ -50,7 +50,7 @@ Keep lines sorted.
 
 <!-- Crates -->
 
-[ansi_term-badge]: https://badge-cache.kominick.com/crates/v/base64.svg?label=ansi_term
+[ansi_term-badge]: https://badge-cache.kominick.com/crates/v/ansi_term.svg?label=ansi_term
 [ansi_term]: https://docs.rs/ansi_term/
 [base64-badge]: https://badge-cache.kominick.com/crates/v/base64.svg?label=base64
 [base64]: https://docs.rs/base64/


### PR DESCRIPTION
The badge of the ansi_term package is pointing incorrectly to the base64 crate, this is causing that the ansi_term package shows a non existent version

![image](https://user-images.githubusercontent.com/5913008/111088953-02e52d00-8500-11eb-8061-2d7e7cfaba40.png)
