### PR TITLE
Convert u8 to char (necessary since rand 0.8)

### DIFF
--- a/src/concurrency/parallel/rayon-parallel-sort.md
+++ b/src/concurrency/parallel/rayon-parallel-sort.md
@@ -19,7 +19,7 @@ fn main() {
   let mut vec = vec![String::new(); 100_000];
   vec.par_iter_mut().for_each(|p| {
     let mut rng = thread_rng();
-    *p = (0..5).map(|_| rng.sample(&Alphanumeric)).collect()
+    *p = (0..5).map(|_| rng.sample(&Alphanumeric) as char).collect()
   });
   vec.par_sort_unstable();
 }


### PR DESCRIPTION
This fixes one breaking skeptic test due to a change in the type of `Alphanumeric` between rand 0.7 and rand 0.8.