### PR TITLE
Use spaces for CSV in indentation

### DIFF
--- a/src/encoding/csv/delimiter.md
+++ b/src/encoding/csv/delimiter.md
@@ -18,9 +18,9 @@ struct Record {
 use csv::ReaderBuilder;
 
 fn main() -> Result<(), Error> {
-    let data = "name\tplace\tid
-		Mark\tMelbourne\t46
-		Ashley\tZurich\t92";
+    let data = "name\tplace\tid\n\
+        Mark\tMelbourne\t46\n\
+        Ashley\tZurich\t92";
 
     let mut reader = ReaderBuilder::new().delimiter(b'\t').from_reader(data.as_bytes());
     for result in reader.deserialize::<Record>() {


### PR DESCRIPTION
The use of tabs for indentation made the example error due to finding more
columns on the indented lines than intended. Use escaped newlines and line
continuations to prevent the indentation from being part of the records.