### PR TITLE
fix #644

### DIFF
--- a/src/web/clients/download/basic.md
+++ b/src/web/clients/download/basic.md
@@ -6,12 +6,12 @@ Creates a temporary directory with [`tempfile::Builder`] and downloads
 a file over HTTP using [`reqwest::get`] asynchronously.
 
 Creates a target [`File`] with name obtained from [`Response::url`] within
-[`tempdir()`] and copies downloaded data into it with [`io::copy`].
+[`tempdir()`] and writes downloaded data into it with [`Writer::write_all`].
 The temporary directory is automatically removed on program exit.
 
 ```rust,edition2018,no_run
 use error_chain::error_chain;
-use std::io::copy;
+use std::io::Write;
 use std::fs::File;
 use tempfile::Builder;
 
@@ -41,15 +41,15 @@ async fn main() -> Result<()> {
         println!("will be located under: '{:?}'", fname);
         File::create(fname)?
     };
-    let content =  response.text().await?;
-    copy(&mut content.as_bytes(), &mut dest)?;
+    let content =  response.bytes().await?;
+    dest.write_all(&content)?;
     Ok(())
 }
 ```
 
 [`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
-[`io::copy`]: https://doc.rust-lang.org/std/io/fn.copy.html
 [`reqwest::get`]: https://docs.rs/reqwest/*/reqwest/fn.get.html
 [`Response::url`]: https://docs.rs/reqwest/*/reqwest/struct.Response.html#method.url
 [`tempfile::Builder`]: https://docs.rs/tempfile/*/tempfile/struct.Builder.html
-[`tempdir()`]: https://docs.rs/tempfile/3.1.0/tempfile/struct.Builder.html#method.tempdir
+[`tempdir()`]: https://docs.rs/tempfile/*/tempfile/struct.Builder.html#method.tempdir
+[`Writer::write_all`]: https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all


### PR DESCRIPTION
fixes #644

love the PR template btw

--------------------------

- [x] the tests are passing locally with `cargo test`
- [x] cookbook renders correctly in `mdbook serve -o`
- [x] commits are squashed into one and rebased to latest master
  - merge is handled by the PR, right? ![image](https://user-images.githubusercontent.com/41446523/113756914-fc516c00-96df-11eb-9765-c9281e977c63.png)
- [x] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
- [x] spell check runs without errors `./ci/spellcheck.sh`
- [ ] link check runs without errors `link-checker ./book`
  - not sure where to get link-checker?
- [x] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [x] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [x] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [x] code identifiers in description are in hyperlinked backticks