### PR TITLE
Upgrade rusqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rayon = "1.0"
 regex = "1.0"
 reqwest = { version = "0.10", features = ["blocking", "json", "stream"] }
 ring = "0.16.11"
-rusqlite = { version = "0.22", features = ["chrono"] }
+rusqlite = { version = "0.25", features = ["chrono"] }
 same-file = "1.0"
 select = "0.4"
 semver = "0.9"

--- a/src/database/sqlite/initialization.md
+++ b/src/database/sqlite/initialization.md
@@ -9,7 +9,6 @@ Use the `rusqlite` crate to open SQLite databases. See
 
 ```rust,edition2018,no_run
 use rusqlite::{Connection, Result};
-use rusqlite::NO_PARAMS;
 
 fn main() -> Result<()> {
     let conn = Connection::open("cats.db")?;
@@ -19,7 +18,7 @@ fn main() -> Result<()> {
              id integer primary key,
              name text not null unique
          )",
-        NO_PARAMS,
+        [],
     )?;
     conn.execute(
         "create table if not exists cats (
@@ -27,7 +26,7 @@ fn main() -> Result<()> {
              name text not null,
              color_id integer not null references cat_colors(id)
          )",
-        NO_PARAMS,
+        [],
     )?;
 
     Ok(())
@@ -36,4 +35,4 @@ fn main() -> Result<()> {
 
 [`Connection::open`]: https://docs.rs/rusqlite/*/rusqlite/struct.Connection.html#method.open
 
-[documentation]: https://github.com/jgallagher/rusqlite#user-content-notes-on-building-rusqlite-and-libsqlite3-sys
+[documentation]: https://github.com/rusqlite/rusqlite#user-content-notes-on-building-rusqlite-and-libsqlite3-sys

--- a/src/database/sqlite/transactions.md
+++ b/src/database/sqlite/transactions.md
@@ -13,7 +13,7 @@ a duplicate color is made, the transaction rolls back.
 
 
 ```rust,edition2018,no_run
-use rusqlite::{Connection, Result, NO_PARAMS};
+use rusqlite::{Connection, Result};
 
 fn main() -> Result<()> {
     let mut conn = Connection::open("cats.db")?;
@@ -29,9 +29,9 @@ fn main() -> Result<()> {
 fn successful_tx(conn: &mut Connection) -> Result<()> {
     let tx = conn.transaction()?;
 
-    tx.execute("delete from cat_colors", NO_PARAMS)?;
-    tx.execute("insert into cat_colors (name) values (?1)", &[&"lavender"])?;
-    tx.execute("insert into cat_colors (name) values (?1)", &[&"blue"])?;
+    tx.execute("delete from cat_colors", [])?;
+    tx.execute("insert into cat_colors (name) values (?1)", ["lavender"])?;
+    tx.execute("insert into cat_colors (name) values (?1)", ["blue"])?;
 
     tx.commit()
 }
@@ -39,10 +39,10 @@ fn successful_tx(conn: &mut Connection) -> Result<()> {
 fn rolled_back_tx(conn: &mut Connection) -> Result<()> {
     let tx = conn.transaction()?;
 
-    tx.execute("delete from cat_colors", NO_PARAMS)?;
-    tx.execute("insert into cat_colors (name) values (?1)", &[&"lavender"])?;
-    tx.execute("insert into cat_colors (name) values (?1)", &[&"blue"])?;
-    tx.execute("insert into cat_colors (name) values (?1)", &[&"lavender"])?;
+    tx.execute("delete from cat_colors", [])?;
+    tx.execute("insert into cat_colors (name) values (?1)", ["lavender"])?;
+    tx.execute("insert into cat_colors (name) values (?1)", ["blue"])?;
+    tx.execute("insert into cat_colors (name) values (?1)", ["lavender"])?;
 
     tx.commit()
 }


### PR DESCRIPTION
`NO_PARAMS` has been deprecated.
For homogeneous parameters, `[value1, value2, ...]` can be used
directly.
For heterogeneous parameters, `params![value1, value2, ...]` is
preferred.

--------------------------
### Things to check before submitting a PR

- [ ] the tests are passing locally with `cargo test`
- [ ] cookbook renders correctly in `mdbook serve -o`
- [X] commits are squashed into one and rebased to latest master
- [ ] spell check runs without errors `./ci/spellcheck.sh`
- [ ] link check runs without errors `link-checker ./book`
- [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [ ] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR