### PR TITLE
Added ImageError handler to error_chain! macro.

### DIFF
--- a/src/concurrency/thread/threadpool-fractal.md
+++ b/src/concurrency/thread/threadpool-fractal.md
@@ -27,6 +27,7 @@ use image::{ImageBuffer, Pixel, Rgb};
 #     foreign_links {
 #         MpscRecv(RecvError);
 #         Io(std::io::Error);
+#         Image(image::ImageError);
 #     }
 # }
 #


### PR DESCRIPTION
It is not compiling because of:
`?` couldn't convert the error to `Error`
   --> src/main.rs:90:35
    |
67  | fn main() -> Result<()> {
    |              ---------- expected `Error` because of this
...
90  |     let _ = img.save("output.png")?;
    |                                   ^ the trait `From<ImageError>` is not implemented for `Error`
