### PR TITLE
listen-unused: Use Ipv4Addr::LOCALHOST constant

### DIFF
--- a/src/net/server/listen-unused.md
+++ b/src/net/server/listen-unused.md
@@ -11,8 +11,7 @@ use std::net::{SocketAddrV4, Ipv4Addr, TcpListener};
 use std::io::{Read, Error};
 
 fn main() -> Result<(), Error> {
-    let loopback = Ipv4Addr::new(127, 0, 0, 1);
-    let socket = SocketAddrV4::new(loopback, 0);
+    let socket = SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0);
     let listener = TcpListener::bind(socket)?;
     let port = listener.local_addr()?;
     println!("Listening on {}, access this port to end the program", port);


### PR DESCRIPTION
[This constant](https://doc.rust-lang.org/std/net/struct.Ipv4Addr.html#impl) should exist in Rust 2018, which uses Rust 1.31.0.