### PR TITLE
querying-the-web-api examples don't work due to missing user-agent-headers

### DIFF
--- a/src/web/clients/api/rest-get.md
+++ b/src/web/clients/api/rest-get.md
@@ -12,6 +12,7 @@ processing the response into User instances.
 ```rust,edition2018,no_run
 use serde::Deserialize;
 use reqwest::Error;
+use reqwest::header::USER_AGENT;
 
 #[derive(Deserialize, Debug)]
 struct User {
@@ -25,7 +26,13 @@ async fn main() -> Result<(), Error> {
                               owner = "rust-lang-nursery",
                               repo = "rust-cookbook");
     println!("{}", request_url);
-    let response = reqwest::get(&request_url).await?;
+    
+    let client = reqwest::Client::new();
+    let response = client
+        .get(request_url)
+        .header(USER_AGENT, "rust-web-api-client") // gh api requires a user-agent header
+        .send()
+        .await?;
 
     let users: Vec<User> = response.json().await?;
     println!("{:?}", users);


### PR DESCRIPTION
Fixed runtime decoding error occurring due to 403 responses from `gh api` because of missing user-agent header

fixes #662 

Feel free to close if you still prefer to use `reqwest::get` for the example but with a different api that doesn't require `user-agent-header`. I'm currently unaware of how to pass headers along with `reqwest::get` and thus used a `reqwest client` in the fix