### PR TITLE
Download example using `response.bytes()` instead of `response.text()`

### DIFF
--- a/src/web/clients/download/basic.md
+++ b/src/web/clients/download/basic.md
@@ -11,8 +11,8 @@ The temporary directory is automatically removed on program exit.
 
 ```rust,edition2018,no_run
 use error_chain::error_chain;
-use std::io::copy;
 use std::fs::File;
+use std::io::Write;
 use tempfile::Builder;
 
 error_chain! {
@@ -41,8 +41,8 @@ async fn main() -> Result<()> {
         println!("will be located under: '{:?}'", fname);
         File::create(fname)?
     };
-    let content =  response.text().await?;
-    copy(&mut content.as_bytes(), &mut dest)?;
+    let content = response.bytes().await?;
+    dest.write(&content)?;
     Ok(())
 }
 ```


### PR DESCRIPTION
The current example for downloading files interprets the response as text, and then turns it into bytes.
```rust
let content = response.text().await?;
copy(&mut content.as_bytes(), &mut dest)?;
```
This is fine if you're downloading text files, but it will corrupt binary files (I found this issue when downloading PNGs).

In order to fix this I suggest using `response.bytes()` directly.

```rust
let content = response.bytes().await?;
dest.write(&content)?;
```
This is how I ended up implementing it and it works great.