### PR TITLE
Add Error to Result added note for tokio

### DIFF
--- a/src/web/clients/requests/get.md
+++ b/src/web/clients/requests/get.md
@@ -37,6 +37,8 @@ fn main() -> Result<()> {
 
 A similar approach can be used by including the [`tokio`] executor
 to make the main function asynchronous, retrieving the same information.
+Make sure to add tokio = {version = "1.21.2", features = ["full"]} to
+your cargo.toml file.
 
 In this example, [`tokio::main`] handles all the heavy executor setup
 and allows sequential code implemented without blocking until `.await`.
@@ -55,7 +57,7 @@ error_chain! {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let res = reqwest::get("http://httpbin.org/get").await?;
     println!("Status: {}", res.status());
     println!("Headers:\n{:#?}", res.headers());


### PR DESCRIPTION
Added error to Result for main, otherwise it won't compile. If tokio isn't added with features = ["full"] main won't work, so I thought it would be a good idea to remind them.

fixes #ISSUE_ID

:tada: Hi and welcome! Please read the text below and remove it - Thank you! :tada:

No worries if anything in these lists is unclear. Just submit the PR and ask away! :+1:

--------------------------
### Things to check before submitting a PR

- [ ] the tests are passing locally with `cargo test`
- [ ] cookbook renders correctly in `mdbook serve -o`
- [ ] commits are squashed into one and rebased to latest master
- [ ] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
    -  if issue does not exist consider creating it or remove the clause
- [ ] spell check runs without errors `./ci/spellcheck.sh`
- [ ] link check runs without errors `link-checker ./book`
- [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [ ] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR

Thank you for reading, you may now delete this text! Thank you! :smile:
