### PR TITLE
fix for science.md links to mathematics chapter

### DIFF
--- a/src/science.md
+++ b/src/science.md
@@ -1,5 +1,37 @@
 # Science
 
-{{#include science/mathematics.md}}
+## science/mathematics
+
+| Recipe                                                                         | Crates                        | Categories                          |
+| ------------------------------------------------------------------------------ | ----------------------------- | ----------------------------------- |
+| [Vector Norm][vector-norm]                                                     | [![ndarray-badge]][ndarray]   | [![cat-science-badge]][cat-science] |
+| [Adding matrices][add-matrices]                                                | [![ndarray-badge]][ndarray]   | [![cat-science-badge]][cat-science] |
+| [Multiplying matrices][multiply-matrices]                                      | [![ndarray-badge]][ndarray]   | [![cat-science-badge]][cat-science] |
+| [Multiply a scalar with a vector with a matrix][multiply-scalar-vector-matrix] | [![ndarray-badge]][ndarray]   | [![cat-science-badge]][cat-science] |
+| [Invert matrix][invert-matrix]                                                 | [![nalgebra-badge]][nalgebra] | [![cat-science-badge]][cat-science] |
+| [Calculating the side length of a triangle][side-length]                       | [![std-badge]][std]           | [![cat-science-badge]][cat-science] |
+| [Verifying tan is equal to sin divided by cos][tan-sin-cos]                    | [![std-badge]][std]           | [![cat-science-badge]][cat-science] |
+| [Distance between two points on the Earth][latitude-longitude]                 | [![std-badge]][std]           | [![cat-science-badge]][cat-science] |
+| [Creating complex numbers][create-complex]                                     | [![num-badge]][num]           | [![cat-science-badge]][cat-science] |
+| [Adding complex numbers][add-complex]                                          | [![num-badge]][num]           | [![cat-science-badge]][cat-science] |
+| [Mathematical functions on complex numbers][mathematical-functions]            | [![num-badge]][num]           | [![cat-science-badge]][cat-science] |
+| [Measures of central tendency][ex-central-tendency]                            | [![std-badge]][std]           | [![cat-science-badge]][cat-science] |
+| [Computing standard deviation][ex-standard-deviation]                          | [![std-badge]][std]           | [![cat-science-badge]][cat-science] |
+| [Big integers][big-integers]                                                   | [![num-badge]][num]           | [![cat-science-badge]][cat-science] |
+
+[vector-norm]: science/mathematics/linear_algebra.html#vector-norm
+[add-matrices]: science/mathematics/linear_algebra.html#adding-matrices
+[multiply-matrices]: science/mathematics/linear_algebra.html#multiplying-matrices
+[multiply-scalar-vector-matrix]: science/mathematics/linear_algebra.html#multiply-a-scalar-with-a-vector-with-a-matrix
+[invert-matrix]: science/mathematics/linear_algebra.html#invert-matrix
+[side-length]: science/mathematics/trigonometry.html#calculating-the-side-length-of-a-triangle
+[tan-sin-cos]: science/mathematics/trigonometry.html#verifying-tan-is-equal-to-sin-divided-by-cos
+[latitude-longitude]: science/mathematics/trigonometry.html#distance-between-two-points-on-the-earth
+[create-complex]: science/mathematics/complex_numbers.html#creating-complex-numbers
+[add-complex]: science/mathematics/complex_numbers.html#adding-complex-numbers
+[mathematical-functions]: science/mathematics/complex_numbers.html#mathematical-functions
+[ex-central-tendency]: science/mathematics/statistics.html#measures-of-central-tendency
+[ex-standard-deviation]: science/mathematics/statistics.html#standard-deviation
+[big-integers]: science/mathematics/miscellaneous.html#big-integers
 
 {{#include links.md}}


### PR DESCRIPTION
fixes #634

Replace #include science/mathematics.md from science.md with the correct links from the root folder.
The same rule is already applied to the web/client section, so it is nothing new.