### PR TITLE
Corrected impossible example in side-length.md

### DIFF
--- a/src/science/mathematics/trigonometry/side-length.md
+++ b/src/science/mathematics/trigonometry/side-length.md
@@ -2,11 +2,11 @@
 
 [![std-badge]][std] [![cat-science-badge]][cat-science]
 
-Calculates the length of the hypotenuse of a right-angle triangle with an angle of 2 radians and opposite side length of 80.
+Calculates the length of the hypotenuse of a right-angle triangle with an angle of 1 radian and opposite side length of 80.
 
 ```rust,edition2018
 fn main() {
-    let angle: f64 = 2.0;
+    let angle: f64 = 1.0;
     let side_length = 80.0;
 
     let hypotenuse = side_length / angle.sin();


### PR DESCRIPTION
A triangle with a right angle (1.57 radians) and an angle of 2 radians cannot exist and is physically impossible.