### PR TITLE
mdbook 4.43 for rust 1.82

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you'd like to read it locally:
 ```bash
 $ git clone https://github.com/rust-lang-nursery/rust-cookbook
 $ cd rust-cookbook
-$ cargo install mdbook --vers "0.4.5"
+$ cargo install mdbook --vers "0.4.43"
 $ mdbook serve --open
 ```
 

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -18,7 +18,7 @@ if [[ "${CONTENT_TESTS:-}" == 1 ]]; then
         pyenv local 3.6.0
         pip3 install --user link-checker==0.1.0
     fi
-    cargo install mdbook --vers '0.4.5' --debug
+    cargo install mdbook --vers '0.4.43' --debug
 fi
 
 exit 0


### PR DESCRIPTION
When Trying to run jamesgraves/rust-cookbook with rust 1.82 as recommended using 0.4.15 the thread paniced.
![image](https://github.com/user-attachments/assets/29b6cf92-32d1-457d-85d6-eea19f7d6b92)

fixes #ISSUE_ID

:tada: Hi and welcome! Please read the text below and remove it - Thank you! :tada:

No worries if anything in these lists is unclear. Just submit the PR and ask away! :+1:

--------------------------
### Things to check before submitting a PR

- [ ] the tests are passing locally with `cargo test`
- [ ] cookbook renders correctly in `mdbook serve -o`
- [ ] commits are squashed into one and rebased to latest master
- [ ] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
    -  if issue does not exist consider creating it or remove the clause
- [ ] spell check runs without errors `./ci/spellcheck.sh`
- [ ] link check runs without errors `link-checker ./book`
- [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [ ] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR

Thank you for reading, you may now delete this text! Thank you! :smile:
