### PR TITLE
fixes #678 Added Edit/Github Icon

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,6 +12,8 @@ src = "src"
 mathjax-support = false
 # theme = "theme"
 additional-css = ["theme/custom.css"]
+git-repository-url = "https://github.com/rust-lang-nursery/rust-cookbook"
+edit-url-template = "https://github.com/rust-lang-nursery/rust-cookbook/edit/master/{path}"
 
 [output.html.playpen]
 editable = false


### PR DESCRIPTION
fixes #678

![Screenshot from 2024-12-12 13-59-42](https://github.com/user-attachments/assets/65081cff-f886-4f6b-ac1d-0cc0509a2401)

fixed?

I don't know if there's a reason why this hasn't been added yet?