### PR TITLE
Fix indent for a crossbeam example

### DIFF
--- a/src/concurrency/thread/crossbeam-complex.md
+++ b/src/concurrency/thread/crossbeam-complex.md
@@ -53,7 +53,7 @@ fn main() {
             let (sendr, recvr) = (snd2.clone(), rcv1.clone());
             // Spawn workers in separate threads
             s.spawn(move |_| {
-            thread::sleep(Duration::from_millis(500));
+                thread::sleep(Duration::from_millis(500));
                 // Receive until channel closes
                 for msg in recvr.iter() {
                     println!("Worker {:?} received {}.",


### PR DESCRIPTION
This patch fixes indent for a crossbeam example: https://rust-lang-nursery.github.io/rust-cookbook/concurrency/threads.html#create-a-parallel-pipeline

:tada: Hi and welcome! Please read the text below and remove it - Thank you! :tada:

No worries if anything in these lists is unclear. Just submit the PR and ask away! :+1:

--------------------------
### Things to check before submitting a PR

- [ ] the tests are passing locally with `cargo xtask test all`
- [ ] commits are squashed into one and rebased to latest master
- [ ] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
    -  if issue does not exist consider creating it or remove the clause
- [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [ ] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR

Thank you for reading, you may now delete this text! Thank you! :smile: