### PR TITLE
Update base64.md not to use deprecated functions

### DIFF
--- a/src/encoding/string/base64.md
+++ b/src/encoding/string/base64.md
@@ -8,12 +8,12 @@ and decodes it with [`decode`].
 ```rust,edition2018
 use anyhow::Result;
 use std::str;
-use base64::{encode, decode};
+use base64::prelude::{Engine as _, BASE64_STANDARD};
 
 fn main() -> Result<()> {
     let hello = b"hello rustaceans";
-    let encoded = encode(hello);
-    let decoded = decode(&encoded)?;
+    let encoded = BASE64_STANDARD.encode(hello);
+    let decoded = BASE64_STANDARD.decode(&encoded)?;
 
     println!("origin: {}", str::from_utf8(hello)?);
     println!("base64 encoded: {}", encoded);
@@ -23,5 +23,5 @@ fn main() -> Result<()> {
 }
 ```
 
-[`decode`]: https://docs.rs/base64/*/base64/fn.decode.html
-[`encode`]: https://docs.rs/base64/*/base64/fn.encode.html
+[`decode`]: https://docs.rs/base64/latest/base64/engine/trait.Engine.html#method.decode
+[`encode`]: https://docs.rs/base64/latest/base64/engine/trait.Engine.html#method.encode


### PR DESCRIPTION
This patch addresses the following warnings:

```
  warning: use of deprecated function `base64::encode`: Use Engine::encode
   --> src/bin/base64.rs:3:14
    |
  3 | use base64::{encode, decode};
    |              ^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

  warning: use of deprecated function `base64::decode`: Use Engine::decode
   --> src/bin/base64.rs:3:22
    |
  3 | use base64::{encode, decode};
    |                      ^^^^^^

  warning: use of deprecated function `base64::encode`: Use Engine::encode
   --> src/bin/base64.rs:7:17
    |
  7 |   let encoded = encode(hello);
    |                 ^^^^^^

  warning: use of deprecated function `base64::decode`: Use Engine::decode
   --> src/bin/base64.rs:8:17
    |
  8 |   let decoded = decode(&encoded)?;
    |                 ^^^^^^
```

Also, this patch updates broken links on decode and encode.

:tada: Hi and welcome! Please read the text below and remove it - Thank you! :tada:

No worries if anything in these lists is unclear. Just submit the PR and ask away! :+1:

--------------------------
### Things to check before submitting a PR

- [ ] the tests are passing locally with `cargo xtask test all`
- [ ] commits are squashed into one and rebased to latest master
- [ ] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
    -  if issue does not exist consider creating it or remove the clause
- [ ] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [ ] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [ ] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [ ] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```

### Things to do after submitting PR
- [ ] check if CI is happy with your PR

Thank you for reading, you may now delete this text! Thank you! :smile: