### PR TITLE
docs(contributing): point to Zulip instead of the retired Gitter room

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,8 +149,8 @@ If there are no errors, it will just print the local Aspell version and exit.
 This project is intended to be simple to contribute to, and to always
 have obvious next work items available. If at any time there is not
 something obvious to contribute, that is a bug. Feel free to ask for
-additional support at the
-[Rust Ecosystem Working Group](https://gitter.im/rust-lang/WG-ecosystem).
+additional support in the cookbook's Zulip channel,
+[#t-lang-docs/cookbook](https://rust-lang.zulipchat.com/#narrow/channel/520946-t-lang-docs.2Fcookbook).
 
 The development process for the cookbook is presently oriented around
 crates: we decide which crates to represent in the cookbook, then come


### PR DESCRIPTION
## Summary

Closes #755.

The Rust Ecosystem Working Group Gitter room is no longer active; the cookbook community now coordinates in `#t-lang-docs/cookbook` on [rust-lang.zulipchat.com](https://rust-lang.zulipchat.com/#narrow/channel/520946-t-lang-docs.2Fcookbook), exactly the channel the issue reporter cited.

## Change

`CONTRIBUTING.md` - swap the stale Gitter link in the "Finding what to contribute" section for the current Zulip channel link. Surrounding prose unchanged.

```diff
-additional support at the
-[Rust Ecosystem Working Group](https://gitter.im/rust-lang/WG-ecosystem).
+additional support in the cookbook's Zulip channel,
+[#t-lang-docs/cookbook](https://rust-lang.zulipchat.com/#narrow/channel/520946-t-lang-docs.2Fcookbook).
```

No other files reference Gitter (`grep -rn gitter --include="*.md"` returned only this line).