### PR TITLE
Cargo.toml: credit top contributors, add curator metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,36 @@ exclude = ["crates/web_leptos", "crates/web_leptos_hydrate"]
 [workspace.package]
 edition = "2024"
 version = "1.1.0"
-authors = ["Brian Anderson <banderson@mozilla.com>", "Andrew Gauger <andygauge@gmail.com>"]
+authors = [
+    "Brian Anderson <banderson@mozilla.com>",
+    "David Tolnay <dtolnay@gmail.com>",
+    "Michał Budzyński <budziq@gmail.com>",
+    "Brad Anderson <brad.anderson1995@gmail.com>",
+    "David Harris <dhharris9@gmail.com>",
+]
 license = "MIT OR Apache-2.0"
 publish = false
+
+[workspace.metadata]
+curator = "Andrew Gauger <andygauge@gmail.com>"
 
 [package]
 name = "rust-cookbook"
 version = "1.1.0"
-authors = ["Brian Anderson <banderson@mozilla.com>", "Andrew Gauger <andygauge@gmail.com>"]
+authors = [
+    "Brian Anderson <banderson@mozilla.com>",
+    "David Tolnay <dtolnay@gmail.com>",
+    "Michał Budzyński <budziq@gmail.com>",
+    "Brad Anderson <brad.anderson1995@gmail.com>",
+    "David Harris <dhharris9@gmail.com>",
+]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 publish = false
 build = "build.rs"
+
+[package.metadata]
+curator = "Andrew Gauger <andygauge@gmail.com>"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- Updates `authors` in `[workspace.package]` and `[package]` to credit the top contributors by commit count, led by Brian Anderson (Mozilla, project originator) and followed by David Tolnay, Michał Budzyński, Brad Anderson, and David Harris.
- Moves Andrew Gauger from `authors` into a new `curator` field under `[workspace.metadata]` and `[package.metadata]` to reflect the maintenance role rather than original authorship. (Cargo ignores `metadata` tables — they are free-form and travel with the manifest.)

## Test plan

- [x] `cargo metadata --no-deps --format-version 1` parses cleanly
- [ ] `cargo xtask test all` (run by reviewer / CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)