### PR TITLE
Add async filesystem recipe under File System

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/algorithms/*", "crates/concurrency/*", "crates/development_tools/debugging/tracing", "crates/safety_critical/*", "crates/web", "xtask"]
+members = ["crates/algorithms/*", "crates/concurrency/*", "crates/development_tools/debugging/tracing", "crates/file/async_fs", "crates/safety_critical/*", "crates/web", "xtask"]
 exclude = ["crates/web_leptos", "crates/web_leptos_hydrate"]
 
 [workspace.package]

--- a/book.toml
+++ b/book.toml
@@ -17,6 +17,10 @@ additional-css = ["theme/custom.css"]
 git-repository-url = "https://github.com/rust-lang-nursery/rust-cookbook"
 edit-url-template = "https://github.com/rust-lang-nursery/rust-cookbook/edit/master/{path}"
 
+[output.html.redirect]
+"/asynchronous.html" = "file/async.html"
+"/asynchronous/fs.html" = "../file/async.html"
+
 [output.html.playpen]
 editable = false
 

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ const REMOVED_PREFIXES: &[&str] = &[
     "./src/development_tools/debugging/tracing/",
     "./src/concurrency/actor/",
     "./src/concurrency/custom_future/",
+    "./src/file/async/",
     "./src/safety_critical/no_panic/",
     "./src/safety_critical/heapless_alloc/",
 ];

--- a/crates/file/async_fs/Cargo.toml
+++ b/crates/file/async_fs/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "async-fs"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["full"] }

--- a/crates/file/async_fs/src/bin/concurrent_read.rs
+++ b/crates/file/async_fs/src/bin/concurrent_read.rs
@@ -1,0 +1,63 @@
+use std::error::Error;
+use std::path::PathBuf;
+use tempfile::tempdir;
+use tokio::fs;
+use tokio::task::JoinSet;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let dir = tempdir()?;
+    let paths: Vec<PathBuf> = (0..5)
+        .map(|i| dir.path().join(format!("part-{i}.log")))
+        .collect();
+
+    for (i, path) in paths.iter().enumerate() {
+        fs::write(path, "x".repeat((i + 1) * 1024)).await?;
+    }
+
+    let mut tasks: JoinSet<std::io::Result<(PathBuf, usize)>> = JoinSet::new();
+    for path in paths {
+        tasks.spawn(async move {
+            let bytes = fs::read(&path).await?;
+            Ok((path, bytes.len()))
+        });
+    }
+
+    let mut total = 0;
+    while let Some(joined) = tasks.join_next().await {
+        let (path, len) = joined??;
+        println!("{}: {len} bytes", path.display());
+        total += len;
+    }
+    println!("total: {total} bytes");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn reads_every_file() -> Result<(), Box<dyn Error>> {
+        let dir = tempdir()?;
+        let paths: Vec<PathBuf> = (0..3)
+            .map(|i| dir.path().join(format!("f-{i}")))
+            .collect();
+        for (i, path) in paths.iter().enumerate() {
+            fs::write(path, vec![0u8; (i + 1) * 10]).await?;
+        }
+
+        let mut tasks: JoinSet<std::io::Result<usize>> = JoinSet::new();
+        for path in paths {
+            tasks.spawn(async move { Ok(fs::read(&path).await?.len()) });
+        }
+
+        let mut total = 0;
+        while let Some(joined) = tasks.join_next().await {
+            total += joined??;
+        }
+        assert_eq!(total, 10 + 20 + 30);
+        Ok(())
+    }
+}

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -43,6 +43,7 @@
 - [File System](file.md)
   - [Read & Write](file/read-write.md)
   - [Directory Traversal](file/dir.md)
+  - [Async I/O](file/async.md)
 - [Hardware Support](hardware.md)
   - [Processor](hardware/processor.md)
 - [Memory Management](mem.md)

--- a/src/file.md
+++ b/src/file.md
@@ -13,6 +13,7 @@
 | [Recursively calculate file sizes at given depth][ex-file-sizes] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Find all png files recursively][ex-glob-recursive] | [![glob-badge]][glob] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Find all files with given pattern ignoring filename case][ex-glob-with] | [![glob-badge]][glob] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Read multiple files concurrently][ex-async-concurrent-read] | [![tokio-badge]][tokio] | [![cat-filesystem-badge]][cat-filesystem] |
 
 [ex-std-read-lines]: file/read-write.html#read-lines-of-strings-from-a-file
 [ex-avoid-read-write]: file/read-write.html#avoid-writing-and-reading-from-a-same-file
@@ -25,5 +26,6 @@
 [ex-file-sizes]: file/dir.html#recursively-calculate-file-sizes-at-given-depth
 [ex-glob-recursive]: file/dir.html#find-all-png-files-recursively
 [ex-glob-with]: file/dir.html#find-all-files-with-given-pattern-ignoring-filename-case
+[ex-async-concurrent-read]: file/async.html#read-multiple-files-concurrently
 
 {{#include links.md}}

--- a/src/file/async.md
+++ b/src/file/async.md
@@ -1,0 +1,5 @@
+# Async I/O
+
+{{#include async/concurrent-read.md}}
+
+{{#include ../links.md}}

--- a/src/file/async/concurrent-read.md
+++ b/src/file/async/concurrent-read.md
@@ -1,0 +1,22 @@
+## Read multiple files concurrently
+
+[![tokio-badge]][tokio] [![cat-filesystem-badge]][cat-filesystem]
+
+Reads several files at once instead of one after another. Each
+read is spawned onto the runtime with [`tokio::task::JoinSet`], so
+the syscalls overlap and total wall time is roughly the slowest
+read rather than the sum of all of them. This is the pattern to
+reach for when collecting log shards, manifest files, or chunked
+uploads from disk.
+
+The example seeds a temp directory with five files, then reads
+them concurrently and reports each file's size and the total. The
+async equivalent of [`std::fs::read`] is [`tokio::fs::read`].
+
+```rust,no_run
+{{#include ../../../crates/file/async_fs/src/bin/concurrent_read.rs:1:33}}
+```
+
+[`std::fs::read`]: https://doc.rust-lang.org/std/fs/fn.read.html
+[`tokio::fs::read`]: https://docs.rs/tokio/*/tokio/fs/fn.read.html
+[`tokio::task::JoinSet`]: https://docs.rs/tokio/*/tokio/task/struct.JoinSet.html


### PR DESCRIPTION
## Summary

- Adds **Read multiple files concurrently** under File System, using [`tokio::fs::read`] + [`tokio::task::JoinSet`] to overlap reads across many files.
- Code lives as a standalone workspace crate at `crates/file/async_fs/` and is pulled into `src/file/async/concurrent-read.md` via mdBook `{{#include}}`, matching the project's preferred pattern for new examples (`crates/algorithms/randomness/`, `crates/concurrency/custom_future/`, etc.).
- Adds two `[output.html.redirect]` entries in `book.toml` so previously-404 URLs (`/asynchronous.html`, `/asynchronous/fs.html`) land on the new recipe.

## Test plan

- [x] `cargo test -p async-fs` — 1 unit test passes
- [x] `cargo test --test skeptic` — 149 passed, 0 failed
- [x] `mdbook build` — succeeds; new page renders at `/file/async.html`
- [x] `./ci/spellcheck.sh list` — clean
- [x] Verified redirects with curl: `/asynchronous.html` and `/asynchronous/fs.html` now serve meta-refresh HTML pointing at `/file/async.html`
- [x] Verified concurrent ordering: running the binary prints reads in non-sequential order, confirming overlap

[`tokio::fs::read`]: https://docs.rs/tokio/*/tokio/fs/fn.read.html
[`tokio::task::JoinSet`]: https://docs.rs/tokio/*/tokio/task/struct.JoinSet.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)