### PR TITLE
Add database recipes for SQLx and SeaORM. Fixes #768

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["crates/algorithms/*", "crates/concurrency/*", "crates/development_tools/debugging/tracing", "crates/safety_critical/*", "crates/wasm", "crates/web", "xtask"]
-exclude = ["crates/web_leptos", "crates/web_leptos_hydrate", "crates/wasm_component_guest", "crates/wasm_component_host"]
+exclude = ["crates/database/sea_orm", "crates/database/sqlx", "crates/web_leptos", "crates/web_leptos_hydrate", "crates/wasm_component_guest", "crates/wasm_component_host"]
 
 [workspace.package]
 edition = "2024"

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,8 @@ const REMOVED_PREFIXES: &[&str] = &[
     "./src/safety_critical/no_panic/",
     "./src/safety_critical/heapless_alloc/",
     "./src/wasm/",
+    "./src/database/sqlx/",
+    "./src/database/sea_orm/",
 ];
 
 fn main() {

--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -310,6 +310,8 @@ SocketAddrV
 spsc
 sqlite
 SQLite
+SQLx
+sqlx
 StatusCode
 stdcell
 stdcelllazycell

--- a/crates/database/sea_orm/Cargo.toml
+++ b/crates/database/sea_orm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sea-orm-recipes"
+version = "1.1.0"
+authors = ["Brian Anderson <banderson@mozilla.com>", "Andrew Gauger <andygauge@gmail.com>"]
+edition = "2024"
+license = "MIT Or Apache-2.0"
+publish = false
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+sea-orm = { version = "1", features = ["sqlx-sqlite", "runtime-tokio-native-tls", "macros"]}

--- a/crates/database/sea_orm/src/bin/simple_orm_pattern.rs
+++ b/crates/database/sea_orm/src/bin/simple_orm_pattern.rs
@@ -1,0 +1,99 @@
+use sea_orm::sea_query::TableCreateStatement;
+use sea_orm::{
+    ActiveModelTrait, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection, DbErr,
+    EntityTrait, Schema, Set,
+};
+
+mod location {
+    use sea_orm::entity::prelude::*;
+
+    #[derive(Debug, Clone, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "location")]
+    pub struct Model {
+        #[sea_orm(primary_key)]
+        pub id: i32,
+        pub name: String,
+        pub latitude: f64,
+        pub longitude: f64,
+    }
+
+    #[derive(Debug, Clone, PartialEq, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+#[tokio::main]
+async fn main() -> Result<(), DbErr> {
+    let db = Database::connect("sqlite::memory:").await?;
+
+    create_location_table(&db).await?;
+
+    let mut null_island = location::ActiveModel {
+        name: Set("Null Island".to_owned()),
+        latitude: Set(0.0),
+        longitude: Set(0.0),
+        ..Default::default()
+    }
+    .save(&db)
+    .await?;
+
+    let location = location::Entity::find().one(&db).await?;
+    println!("{location:?}");
+
+    null_island.name = Set("Null Island V2".to_owned());
+    let null_island = null_island.save(&db).await?;
+
+    println!("Updated location: {null_island:?}");
+    Ok(())
+}
+
+async fn create_location_table(db: &DatabaseConnection) -> Result<(), DbErr> {
+    let builder = DatabaseBackend::Sqlite;
+    let schema = Schema::new(builder);
+
+    let statement: TableCreateStatement = schema.create_table_from_entity(location::Entity);
+    db.execute(builder.build(&statement)).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create_location_table, location};
+    use sea_orm::{ActiveModelTrait, Database, EntityTrait, Set, Unchanged};
+
+    #[tokio::test]
+    async fn test_seaorm_insert_and_select() -> Result<(), sea_orm::DbErr> {
+        let db = Database::connect("sqlite::memory:").await?;
+
+        create_location_table(&db).await?;
+
+        let mut null_island = location::ActiveModel {
+            name: Set("Null Island".to_owned()),
+            latitude: Set(0.0),
+            longitude: Set(0.0),
+            ..Default::default()
+        }
+        .save(&db)
+        .await?;
+
+        let location = location::Entity::find().one(&db).await?;
+
+        assert_eq!(
+            location,
+            Some(location::Model {
+                id: 1,
+                name: "Null Island".to_owned(),
+                latitude: 0.0,
+                longitude: 0.0,
+            })
+        );
+
+        null_island.name = Set("Null Island V2".to_owned());
+        let null_island = null_island.save(&db).await?;
+
+        assert_eq!(null_island.name, Unchanged("Null Island V2".to_owned()));
+
+        Ok(())
+    }
+}

--- a/crates/database/sqlx/Cargo.toml
+++ b/crates/database/sqlx/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sqlx-recipes"
+version = "1.1.0"
+authors = ["Brian Anderson <banderson@mozilla.com>", "Andrew Gauger <andygauge@gmail.com>"]
+edition = "2024"
+license= "MIT OR Apache-2.0"
+publish = false
+
+[features]
+default = []
+macros = ["sqlx/macros"]
+
+[dependencies]
+tokio = { version = "1", features = ["full"]}
+sqlx = { version = "0.8", features = ["sqlite", "postgres", "runtime-tokio"] }
+
+[[bin]]
+name = "query_macros"
+path = "src/bin/query_macros.rs"
+required-features = ["macros"]

--- a/crates/database/sqlx/src/bin/query_macros.rs
+++ b/crates/database/sqlx/src/bin/query_macros.rs
@@ -1,0 +1,28 @@
+use sqlx::{Connection, Error, postgres::PgConnection};
+
+struct Location {
+    name: String,
+    latitude: f64,
+    longitude: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let mut conn =
+        PgConnection::connect("postgresql://postgres:postgres@localhost/locations").await?;
+
+    let location = sqlx::query_as!(
+        Location,
+        "SELECT  name, latitude, longitude FROM location where id = $1",
+        1i32
+    )
+    .fetch_one(&mut conn)
+    .await?;
+
+    println!(
+        "{} is at coordinates latitude: {} and longitude: {}",
+        location.name, location.latitude, location.longitude
+    );
+
+    Ok(())
+}

--- a/crates/database/sqlx/src/bin/sqlite_pool.rs
+++ b/crates/database/sqlx/src/bin/sqlite_pool.rs
@@ -1,0 +1,89 @@
+use sqlx::{Error, Row, sqlite::SqlitePoolOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect("sqlite::memory:")
+        .await?;
+
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS location (
+            id                  INTEGER PRIMARY KEY,
+            name                TEXT NOT NULL,
+            latitude            REAL NOT NULL,
+            longitude           REAL NOT NULL
+            )
+        ",
+    )
+    .execute(&pool)
+    .await?;
+
+    sqlx::query("INSERT INTO location (name, latitude, longitude) VALUES (?1, ?2, ?3)")
+        .bind("Null Island")
+        .bind(0.00)
+        .bind(0.00)
+        .execute(&pool)
+        .await?;
+
+    sqlx::query("INSERT INTO location (name, latitude, longitude) VALUES (?1, ?2, ?3)")
+        .bind("Titanic")
+        .bind(41.726931)
+        .bind(-49.948253)
+        .execute(&pool)
+        .await?;
+
+    let locations = sqlx::query("SELECT name, latitude, longitude FROM location")
+        .fetch_all(&pool)
+        .await?;
+
+    for row in locations {
+        let name: String = row.try_get("name")?;
+        let lat: f64 = row.try_get("latitude")?;
+        let longitude: f64 = row.try_get("longitude")?;
+        println!("{name} is at coordinates latitude: {lat} and longitude: {longitude}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::Row;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    #[tokio::test]
+    async fn test_sqlite_pool_insert_and_select() -> Result<(), sqlx::Error> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS location (
+            id                  INTEGER PRIMARY KEY,
+            name                TEXT NOT NULL,
+            latitude            REAL NOT NULL,
+            longitude           REAL NOT NULL
+            )
+        ",
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query("INSERT INTO location (name, latitude, longitude) VALUES (?1, ?2, ?3)")
+            .bind("Null Island")
+            .bind(0.00)
+            .bind(0.00)
+            .execute(&pool)
+            .await?;
+
+        let locations = sqlx::query("SELECT name, latitude, longitude FROM location")
+            .fetch_all(&pool)
+            .await?;
+
+        assert_eq!(locations.len(), 1);
+        let name: String = locations[0].try_get("name")?;
+        assert_eq!(name, "Null Island");
+        Ok(())
+    }
+}

--- a/crates/database/sqlx/src/bin/transactions.rs
+++ b/crates/database/sqlx/src/bin/transactions.rs
@@ -1,0 +1,28 @@
+use sqlx::{Error, postgres::PgPoolOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let pool = PgPoolOptions::new()
+        .max_connections(3)
+        .connect("postgresql://postgres:postgres@localhost/locations")
+        .await?;
+
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("INSERT INTO location (name, latitude, longitude) VALUES ($1, $2, $3)")
+        .bind("Area 51")
+        .bind(37.2350)
+        .bind(-115.8111)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("INSERT INTO location (name, latitude, longitude) VALUES ($1, $2, $3)")
+        .bind("Point Nemo")
+        .bind(-48.8767)
+        .bind(-123.3933)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+    Ok(())
+}

--- a/crates/database/sqlx/src/bin/typed_rows.rs
+++ b/crates/database/sqlx/src/bin/typed_rows.rs
@@ -1,0 +1,27 @@
+use sqlx::{Error, postgres::PgPool};
+
+#[derive(sqlx::FromRow)]
+struct Location {
+    name: String,
+    latitude: f64,
+    longitude: f64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let pool =
+        PgPool::connect("postgresql://postgres:postgres@localhost/locations").await?;
+
+    let locations = sqlx::query_as::<_, Location>("SELECT name, latitude, longitude FROM location")
+        .fetch_all(&pool)
+        .await?;
+
+    for location in locations {
+        println!(
+            "{} is at coordinates latitude: {} and longitude: {}",
+            location.name, location.latitude, location.longitude
+        );
+    }
+
+    Ok(())
+}

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,6 +32,8 @@
 - [Database](database.md)
   - [SQLite](database/sqlite.md)
   - [Postgres](database/postgres.md)
+  - [SQLx](database/sqlx.md)
+  - [Sea ORM](database/sea_orm.md)
 - [Date and Time](datetime.md)
   - [Duration and Calculation](datetime/duration.md)
   - [Parsing and Displaying](datetime/parse.md)

--- a/src/database.md
+++ b/src/database.md
@@ -7,11 +7,21 @@
 | [Create tables in a Postgres database][ex-postgres-create-tables] | [![postgres-badge]][postgres] | [![cat-database-badge]][cat-database] |
 | [Insert and Query data][ex-postgres-insert-query-data] | [![postgres-badge]][postgres] | [![cat-database-badge]][cat-database] |
 | [Aggregate data][ex-postgres-aggregate-data] | [![postgres-badge]][postgres] | [![cat-database-badge]][cat-database] |
+| [Connect to SQLite pool and simple query][ex-sqlx-sqlite-pool] | [![sqlx-badge]][sqlx] | [![cat-database-badge]][cat-database] |
+| [Connect to Pg Pool and query typed rows][ex-sqlx-postgres-pool-typed-rows] | [![sqlx-badge]][sqlx] | [![cat-database-badge]][cat-database] |
+| [Compile-time checked queries][ex-sqlx-checked-queries] | [![sqlx-badge]][sqlx] | [![cat-database-badge]][cat-database] |
+| [Transactions in SQLx][ex-sqlx-transactions-sqlx] | [![sqlx-badge]][sqlx] | [![cat-database-badge]][cat-database] |
+| [Simple ORM pattern][ex-sea_orm-simple-orm] | [![sea_orm-badge]][sea_orm] | [![cat-database-badge]][cat-database] |
 
 [ex-sqlite-initialization]: database/sqlite.html#create-a-sqlite-database
 [ex-sqlite-insert-select]:  database/sqlite.html#insert-and-select-data
 [ex-postgres-create-tables]: database/postgres.html#create-tables-in-a-postgres-database
 [ex-postgres-insert-query-data]: database/postgres.html#insert-and-query-data
 [ex-postgres-aggregate-data]: database/postgres.html#aggregate-data
+[ex-sqlx-sqlite-pool]: database/sqlx.html#connect-to-sqlite-and-query-data
+[ex-sqlx-postgres-pool-typed-rows]: database/sqlx.html#connect-to-postgres-and-query-typed-rows
+[ex-sqlx-checked-queries]: database/sqlx.html#compile-time-checked-queries
+[ex-sqlx-transactions-sqlx]: database/sqlx.html#transactions-with-sqlx
+[ex-sea_orm-simple-orm]: database/sea_orm.html#simple-orm-pattern
 
 {{#include links.md}}

--- a/src/database/sea_orm.md
+++ b/src/database/sea_orm.md
@@ -1,0 +1,14 @@
+# SeaORM
+
+[`SeaORM`][sea_orm] maps database tables to Rust entities and active models, so
+you can create, query, and update rows with typed values instead of writing raw
+SQL for each step. The entity in the recipe below shows the generated Rust
+types clearly, but you do not need to write all of that code by hand when you
+already have a database schema. Use [`sea-orm-cli`] to generate entities from
+an existing database.
+
+{{#include sea_orm/simple_orm_pattern.md}}
+
+{{#include ../links.md}}
+
+[`sea-orm-cli`]: https://www.sea-ql.org/SeaORM/docs/generate-entity/sea-orm-cli/

--- a/src/database/sea_orm/simple_orm_pattern.md
+++ b/src/database/sea_orm/simple_orm_pattern.md
@@ -1,0 +1,16 @@
+## Create, query, and update rows with SeaORM
+[![sea_orm-badge]][sea_orm] [![cat-database-badge]][cat-database]
+
+Use [`Database::connect`] to open an in-memory SQLite database and
+[`Schema::create_table_from_entity`] to create a table from a SeaORM entity.
+Create a row with [`ActiveModelTrait::save`], load it with [`EntityTrait::find`],
+then update it and check the saved value returned by [`ActiveModelTrait::save`].
+
+```rust
+{{#include ../../../crates/database/sea_orm/src/bin/simple_orm_pattern.rs::58 }}
+```
+
+[`Database::connect`]: https://docs.rs/sea_orm/*/sea_orm/struct.Database.html#method.connect
+[`Schema::create_table_from_entity`]: https://docs.rs/sea_orm/*/sea_orm/schema/struct.Schema.html#method.create_table_from_entity
+[`ActiveModelTrait::save`]: https://docs.rs/sea_orm/*/sea_orm/entity/trait.ActiveModelTrait.html#method.save
+[`EntityTrait::find`]: https://docs.rs/sea_orm/*/sea_orm/entity/trait.EntityTrait.html#tymethod.find

--- a/src/database/sqlx.md
+++ b/src/database/sqlx.md
@@ -1,0 +1,19 @@
+# SQLx
+
+[`sqlx`][sqlx] is an async SQL toolkit for Rust. It supports connection pools, prepared queries, transactions, and compile-time
+checked queries for supported databases. To use [`sqlx`][sqlx] in your application, add the following crates to your project:
+
+```shell
+cargo add tokio --features full
+cargo add sqlx --features sqlite,postgres,runtime-tokio
+```
+
+{{#include sqlx/sqlite_pool.md}}
+
+{{#include sqlx/postgres_pool_typed_rows.md}}
+
+{{#include sqlx/query_macros.md}}
+
+{{#include sqlx/transactions.md}}
+
+{{#include ../links.md}}

--- a/src/database/sqlx/postgres_pool_typed_rows.md
+++ b/src/database/sqlx/postgres_pool_typed_rows.md
@@ -1,0 +1,17 @@
+## Connect to Postgres and query typed rows
+
+[![sqlx-badge]][sqlx] [![cat-database-badge]][cat-database]
+
+Use [`PgPool::connect`] to open a connection pool for an existing `locations` Postgres
+database. Query values in the database and map query results into a typed `Location` struct with
+[`sqlx::query_as`] and [`FromRow`], then load all rows with
+[`QueryAs::fetch_all`].
+
+```rust,no_run
+{{#include ../../../crates/database/sqlx/src/bin/typed_rows.rs }}
+```
+
+[`PgPool::connect`]: https://docs.rs/sqlx/*/sqlx/struct.Pool.html#method.connect
+[`sqlx::query_as`]: https://docs.rs/sqlx/*/sqlx/fn.query_as.html
+[`FromRow`]: https://docs.rs/sqlx/*/sqlx/trait.FromRow.html
+[`QueryAs::fetch_all`]: https://docs.rs/sqlx/*/sqlx/query/struct.QueryAs.html#method.fetch_all

--- a/src/database/sqlx/query_macros.md
+++ b/src/database/sqlx/query_macros.md
@@ -1,0 +1,23 @@
+## Compile-time checked queries
+
+[![sqlx-badge]][sqlx] [![cat-database-badge]][cat-database]
+
+Use [`Connection::connect`] to open a Postgres connection and
+[`sqlx::query_as!`] to validate the SQL query against the database schema at
+compile time. The macro maps the selected columns into a `Location` struct
+and fetches a single row using [`Query::fetch_one`].
+
+```rust,ignore
+{{#include ../../../crates/database/sqlx/src/bin/query_macros.rs }}
+```
+
+Set `DATABASE_URL` to a Postgres database that already contains the `location`
+table before building. This may be achieved by either adding a `DATABASE_URL` variable
+to a `.env` file or running:
+
+```shell
+export DATABASE_URL=<your_database_url>
+```
+[`Query::fetch_one`]: https://docs.rs/sqlx/latest/sqlx/query/struct.Query.html#method.fetch_one
+[`Connection::connect`]: https://docs.rs/sqlx/*/sqlx/trait.Connection.html#tymethod.connect
+[`sqlx::query_as!`]: https://docs.rs/sqlx/*/sqlx/macro.query_as.html

--- a/src/database/sqlx/sqlite_pool.md
+++ b/src/database/sqlx/sqlite_pool.md
@@ -1,0 +1,17 @@
+## Connect to SQLite and query data
+
+[![sqlx-badge]][sqlx] [![cat-database-badge]][cat-database]
+
+Use [`SqlitePoolOptions::connect`] to open an in-memory SQLite database backed by a connection pool that only allows a maximum of 1 concurrent connections.
+Create a table and insert rows with [`sqlx::query`] and [`Executor::execute`], then load the results with [`Query::fetch_all`].
+Each row is read by calling [`Row::try_get`] for the selected columns.
+
+```rust,no_run
+{{#include ../../../crates/database/sqlx/src/bin/sqlite_pool.rs::47 }}
+```
+
+[`SqlitePoolOptions::connect`]: https://docs.rs/sqlx/*/sqlx/sqlite/type.SqlitePoolOptions.html#method.connect
+[`sqlx::query`]: https://docs.rs/sqlx/*/sqlx/fn.query.html
+[`Executor::execute`]: https://docs.rs/sqlx/*/sqlx/trait.Executor.html#method.execute
+[`Query::fetch_all`]: https://docs.rs/sqlx/*/sqlx/query/struct.Query.html#method.fetch_all
+[`Row::try_get`]: https://docs.rs/sqlx/*/sqlx/trait.Row.html#method.try_get

--- a/src/database/sqlx/transactions.md
+++ b/src/database/sqlx/transactions.md
@@ -1,0 +1,17 @@
+## Transactions with SQLx
+
+[![sqlx-badge]][sqlx] [![cat-database-badge]][cat-database]
+
+Use [`PgPoolOptions::connect`] to open a connection pool for an existing
+`locations` Postgres database. Start a transaction with [`Pool::begin`], run
+two `INSERT` statements with [`sqlx::query`], and save both rows together with
+[`Transaction::commit`].
+
+```rust,no_run
+{{#include ../../../crates/database/sqlx/src/bin/transactions.rs }}
+```
+
+[`PgPoolOptions::connect`]: https://docs.rs/sqlx/*/sqlx/postgres/type.PgPoolOptions.html#method.connect
+[`Pool::begin`]: https://docs.rs/sqlx/*/sqlx/struct.Pool.html#method.begin
+[`sqlx::query`]: https://docs.rs/sqlx/*/sqlx/fn.query.html
+[`Transaction::commit`]: https://docs.rs/sqlx/*/sqlx/struct.Transaction.html#method.commit

--- a/src/links.md
+++ b/src/links.md
@@ -139,6 +139,8 @@ Keep lines sorted.
 [rusqlite]: https://crates.io/crates/rusqlite/
 [same_file-badge]: https://img.shields.io/crates/v/same_file.svg?label=same_file
 [same_file]: https://docs.rs/same-file/
+[sea_orm-badge]: https://img.shields.io/crates/v/sea_orm.svg?label=sea_orm
+[sea_orm]: https://docs.rs/sea_orm/*/sea_orm
 [select-badge]: https://img.shields.io/crates/v/select.svg?label=select
 [select]: https://docs.rs/select/
 [semver-badge]: https://img.shields.io/crates/v/semver.svg?label=semver
@@ -147,6 +149,8 @@ Keep lines sorted.
 [serde-json-badge]: https://img.shields.io/crates/v/serde_json.svg?label=serde_json
 [serde-json]: https://docs.rs/serde_json/*/serde_json/
 [serde]: https://docs.rs/serde/
+[sqlx-badge]: https://img.shields.io/crates/v/sqlx.svg?label=sqlx
+[sqlx]: https://docs.rs/sqlx/*/sqlx
 [std-badge]: https://img.shields.io/badge/std-1.29.1-blue.svg
 [std]: https://doc.rust-lang.org/std
 [syslog-badge]: https://img.shields.io/crates/v/syslog.svg?label=syslog


### PR DESCRIPTION
fixes #768

Tests are passing except for links. There are 4 links outside the scope of this PR that are broken. Not sure if I should address them or not.

### Checklist
- [x] the tests are passing locally with `cargo xtask test all` 
- [x] commits are squashed into one and rebased to latest master
- [x] PR contains correct "fixes #ISSUE_ID" clause to autoclose the issue on PR merge
    -  if issue does not exist consider creating it or remove the clause
- [x] non rendered items are in sorted order (links, reference, identifiers, Cargo.toml)
- [x] links to docs.rs have wildcard version `https://docs.rs/tar/*/tar/struct.Entry.html`
- [x] example has standard [error handling](https://rust-lang-nursery.github.io/rust-cookbook/about.html#a-note-about-error-handling)
- [x] code identifiers in description are in hyperlinked backticks
```markdown
[`Entry::unpack`]: https://docs.rs/tar/*/tar/struct.Entry.html#method.unpack
```
### Things to do after submitting PR
- [x] check if CI is happy with your PR
