### PR TITLE
Fix async section: add to homepage TOC, unwrap Cargo snippets from blockquotes

### DIFF
--- a/src/asynchronous/channel/bounded.md
+++ b/src/asynchronous/channel/bounded.md
@@ -63,11 +63,12 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`sync`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "sync"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`sync`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "sync"] }
+```
 
 [`bounded channel`]: https://docs.rs/tokio/*/tokio/sync/mpsc/fn.channel.html
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros

--- a/src/asynchronous/channel/unbounded.md
+++ b/src/asynchronous/channel/unbounded.md
@@ -61,11 +61,12 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`sync`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "sync"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`sync`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "sync"] }
+```
 
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros
 [`sync`]: https://docs.rs/crate/tokio/*/features#sync

--- a/src/asynchronous/fs/create.md
+++ b/src/asynchronous/fs/create.md
@@ -29,11 +29,12 @@ async fn main() -> io::Result<()> {
 ```
 
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "fs"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "fs"] }
+```
 
 [`File::create`]: https://docs.rs/tokio/*/tokio/fs/struct.File.html#method.create
 [`create_dir_all`]: https://docs.rs/tokio/*/tokio/fs/fn.create_dir_all.html

--- a/src/asynchronous/fs/read.md
+++ b/src/asynchronous/fs/read.md
@@ -30,11 +30,12 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "fs"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "fs"] }
+```
 
 [`fs`]: https://docs.rs/crate/tokio/*/features#fs
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros

--- a/src/asynchronous/fs/remove.md
+++ b/src/asynchronous/fs/remove.md
@@ -27,11 +27,12 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "fs"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "fs"] }
+```
 
 [`fs`]: https://docs.rs/crate/tokio/*/features#fs
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros

--- a/src/asynchronous/fs/rw_traits.md
+++ b/src/asynchronous/fs/rw_traits.md
@@ -38,11 +38,12 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`], [`io-util`] and [`fs`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "fs", "io-util"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`], [`io-util`] and [`fs`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "fs", "io-util"] }
+```
 
 [`AsyncReadExt`]: https://docs.rs/tokio/*/tokio/io/trait.AsyncReadExt.html
 [`AsyncRead`]: https://docs.rs/tokio/*/tokio/io/trait.AsyncRead.html

--- a/src/asynchronous/fs/write.md
+++ b/src/asynchronous/fs/write.md
@@ -17,11 +17,12 @@ async fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "fs"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`fs`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "fs"] }
+```
 
 [`fs`]: https://docs.rs/crate/tokio/*/features#fs
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros

--- a/src/asynchronous/ftc/ctrl_c.md
+++ b/src/asynchronous/ftc/ctrl_c.md
@@ -39,11 +39,12 @@ async fn main() {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`signal`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "signal"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`signal`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "signal"] }
+```
 
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros
 [`signal`]: https://docs.rs/crate/tokio/*/features#signal

--- a/src/asynchronous/join.md
+++ b/src/asynchronous/join.md
@@ -55,11 +55,12 @@ async fn main() {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`rt`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "rt"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`rt`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "rt"] }
+```
 
 {{#include ../links.md}}
 

--- a/src/asynchronous/rt/tokio-rt-builder.md
+++ b/src/asynchronous/rt/tokio-rt-builder.md
@@ -35,11 +35,12 @@ fn main() -> io::Result<()> {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`rt-multi-thread`] feature enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["rt-multi-thread"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`rt-multi-thread`] feature enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["rt-multi-thread"] }
+```
 
 [`Builder`]: https://docs.rs/tokio/*/tokio/runtime/struct.Builder.html
 [`rt-multi-thread`]: https://docs.rs/crate/tokio/*/features#rt-multi-thread

--- a/src/asynchronous/rt/tokio-rt-macro.md
+++ b/src/asynchronous/rt/tokio-rt-macro.md
@@ -18,11 +18,12 @@ async fn main() {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`rt-multi-thread`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "rt-multi-thread"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`rt-multi-thread`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "rt-multi-thread"] }
+```
 
 [`macros`]: https://docs.rs/crate/tokio/*/features#macros
 [`rt-multi-thread`]: https://docs.rs/crate/tokio/*/features#rt-multi-thread

--- a/src/asynchronous/timeout.md
+++ b/src/asynchronous/timeout.md
@@ -26,11 +26,12 @@ async fn main() {
 }
 ```
 
-> Add `tokio` to `Cargo.toml` with the [`macros`] and [`time`] features enabled.
-> ```toml
-> [dependencies]
-> tokio = { version = "*", features = ["macros", "time"] }
-> ```
+Add `tokio` to `Cargo.toml` with the [`macros`] and [`time`] features enabled.
+
+```toml
+[dependencies]
+tokio = { version = "*", features = ["macros", "time"] }
+```
 
 {{#include ../links.md}}
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -18,6 +18,8 @@ community. It needs and welcomes help. For details see
 
 {{#include algorithms.md}}
 
+{{#include asynchronous.md}}
+
 {{#include cli.md}}
 
 {{#include compression.md}}


### PR DESCRIPTION
## Summary

- Add `{{#include asynchronous.md}}` to `src/intro.md` so the Asynchronous section appears in the homepage table of contents alongside all other chapters — it was only reachable via the sidebar.
- Remove the `>` blockquote wrapping from the Cargo.toml dependency snippets across all 12 async pages. The blockquote caused mdBook to merge the prose and the code fence into one callout box instead of rendering them separately.

## Test plan

- [x] `mdbook build` completes without errors
- [x] Homepage (`index.html`) contains the Asynchronous section table
- [ ] Each async page shows the Cargo snippet as a standalone code block below a plain paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)