### PR TITLE
Hide test module from rand.rs recipe

### DIFF
--- a/src/algorithms/randomness/rand.md
+++ b/src/algorithms/randomness/rand.md
@@ -8,7 +8,7 @@ range of the type, and floating point numbers are uniformly distributed from 0 u
 including 1.
 
 ```rust
-{{#include ../../../crates/algorithms/randomness/src/bin/rand.rs }}
+{{#include ../../../crates/algorithms/randomness/src/bin/rand.rs::7 }}
 ```
 
 [`rand::Rng`]: https://docs.rs/rand/0.9/rand/trait.Rng.html


### PR DESCRIPTION
fixes #779

## Summary

The `{{#include}}` for `rand.rs` had no line range, so the `#[cfg(test)]` block was rendered in the book. Cap the include at line 7 (the closing `}` of `main`), matching the pattern already used for `passwd.rs::15`.

## Test plan

- [ ] `mdbook build` succeeds
- [ ] https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html no longer shows the test module under "Generate random numbers"

🤖 Generated with [Claude Code](https://claude.com/claude-code)