### PR TITLE
Fix broken tracing badge images

### DIFF
--- a/src/links.md
+++ b/src/links.md
@@ -161,9 +161,9 @@ Keep lines sorted.
 [tokio]: https://docs.rs/tokio/
 [toml-badge]: https://img.shields.io/crates/v/toml.svg?label=toml
 [toml]: https://docs.rs/toml/
-[tracing-badge]: https://badge-cache.kominick.com/crates/v/tracing.svg?label=tracing
+[tracing-badge]: https://img.shields.io/crates/v/tracing.svg?label=tracing
 [tracing]: https://docs.rs/tracing/
-[tracing-subscriber-badge]: https://badge-cache.kominick.com/crates/v/tracing-subscriber.svg?label=tracing-subscriber
+[tracing-subscriber-badge]: https://img.shields.io/crates/v/tracing-subscriber.svg?label=tracing-subscriber
 [tracing-subscriber]: https://docs.rs/tracing-subscriber/
 [url-badge]: https://img.shields.io/crates/v/url.svg?label=url
 [url]: https://docs.rs/url/


### PR DESCRIPTION
## Summary

`badge-cache.kominick.com` is no longer operational, causing the `tracing` and `tracing-subscriber` badges on the [Tracing Messages](https://rust-lang-nursery.github.io/rust-cookbook/development_tools/debugging/tracing.html) page to render as broken images. Switch both URLs to `img.shields.io` to match every other badge in `links.md`.

## Test plan

- [ ] Tracing page shows version badges instead of broken images

🤖 Generated with [Claude Code](https://claude.com/claude-code)