### PR TITLE
Add WebAssembly section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["crates/algorithms/*", "crates/concurrency/*", "crates/development_tools/debugging/tracing", "crates/safety_critical/*", "crates/web", "xtask"]
-exclude = ["crates/web_leptos", "crates/web_leptos_hydrate"]
+members = ["crates/algorithms/*", "crates/concurrency/*", "crates/development_tools/debugging/tracing", "crates/safety_critical/*", "crates/wasm", "crates/web", "xtask"]
+exclude = ["crates/web_leptos", "crates/web_leptos_hydrate", "crates/wasm_component_guest", "crates/wasm_component_host"]
 
 [workspace.package]
 edition = "2024"

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ const REMOVED_TESTS: &[&str] = &[
     "./src/web/clients/api/rate-limited.md",
     "./src/concurrency/parallel/rayon-parallel-sort.md",
     "./src/web/leptos.md",
+    "./src/wasm.md",
 ];
 
 const REMOVED_PREFIXES: &[&str] = &[
@@ -15,6 +16,7 @@ const REMOVED_PREFIXES: &[&str] = &[
     "./src/concurrency/custom_future/",
     "./src/safety_critical/no_panic/",
     "./src/safety_critical/heapless_alloc/",
+    "./src/wasm/",
 ];
 
 fn main() {

--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -370,7 +370,10 @@ Walkdir
 WalkDir
 wasm
 WASM
+wasi
+wasmtime
 WebAssembly
+webassembly
 webpage
 webservice
 whitespace

--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -94,6 +94,7 @@ DirEntry
 distr
 dotfiles
 DynamicImage
+embeddable
 endian
 endif
 enum

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wasm"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[dependencies]
+anyhow = "1.0"
+wasmtime = "45"

--- a/crates/wasm/src/bin/call_export.rs
+++ b/crates/wasm/src/bin/call_export.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use wasmtime::{Engine, Instance, Module, Store};
+
+fn main() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (func (export "add") (param i32 i32) (result i32)
+                local.get 0
+                local.get 1
+                i32.add)
+        )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let add = instance.get_typed_func::<(i32, i32), i32>(&mut store, "add")?;
+    let result = add.call(&mut store, (5, 37))?;
+    println!("5 + 37 = {result}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() -> Result<()> {
+        let engine = Engine::default();
+        let module = Module::new(
+            &engine,
+            r#"
+            (module
+                (func (export "add") (param i32 i32) (result i32)
+                    local.get 0
+                    local.get 1
+                    i32.add)
+            )
+            "#,
+        )?;
+        let mut store = Store::new(&engine, ());
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let add = instance.get_typed_func::<(i32, i32), i32>(&mut store, "add")?;
+        assert_eq!(add.call(&mut store, (5, 37))?, 42);
+        Ok(())
+    }
+}

--- a/crates/wasm/src/bin/host_fn.rs
+++ b/crates/wasm/src/bin/host_fn.rs
@@ -1,0 +1,85 @@
+use anyhow::Result;
+use wasmtime::{Caller, Engine, Extern, Func, Instance, Module, Store};
+
+fn main() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (import "host" "print" (func $print (param i32 i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 0) "Hello from WebAssembly!")
+            (func (export "run")
+                (call $print (i32.const 0) (i32.const 23)))
+        )
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let print_fn = Func::wrap(
+        &mut store,
+        |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
+            if let Some(Extern::Memory(mem)) = caller.get_export("memory") {
+                let data = mem.data(&caller);
+                let bytes = &data[ptr as usize..(ptr + len) as usize];
+                if let Ok(s) = std::str::from_utf8(bytes) {
+                    println!("[wasm] {s}");
+                }
+            }
+        },
+    );
+
+    let imports = [print_fn.into()];
+    let instance = Instance::new(&mut store, &module, &imports)?;
+    let run = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+    run.call(&mut store, ())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn test_host_fn_receives_message() -> Result<()> {
+        let engine = Engine::default();
+        let module = Module::new(
+            &engine,
+            r#"
+            (module
+                (import "host" "print" (func $print (param i32 i32)))
+                (memory (export "memory") 1)
+                (data (i32.const 0) "Hello from WebAssembly!")
+                (func (export "run")
+                    (call $print (i32.const 0) (i32.const 23)))
+            )
+            "#,
+        )?;
+
+        let captured = Arc::new(Mutex::new(String::new()));
+        let captured_clone = captured.clone();
+        let mut store = Store::new(&engine, ());
+        let print_fn = Func::wrap(
+            &mut store,
+            move |mut caller: Caller<'_, ()>, ptr: i32, len: i32| {
+                if let Some(Extern::Memory(mem)) = caller.get_export("memory") {
+                    let data = mem.data(&caller);
+                    let bytes = &data[ptr as usize..(ptr + len) as usize];
+                    if let Ok(s) = std::str::from_utf8(bytes) {
+                        *captured_clone.lock().unwrap() = s.to_string();
+                    }
+                }
+            },
+        );
+
+        let imports = [print_fn.into()];
+        let instance = Instance::new(&mut store, &module, &imports)?;
+        let run = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+        run.call(&mut store, ())?;
+
+        assert_eq!(*captured.lock().unwrap(), "Hello from WebAssembly!");
+        Ok(())
+    }
+}

--- a/crates/wasm/src/bin/linear_memory.rs
+++ b/crates/wasm/src/bin/linear_memory.rs
@@ -1,0 +1,66 @@
+use anyhow::{anyhow, Result};
+use wasmtime::{Engine, Instance, Module, Store};
+
+fn main() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (memory (export "memory") 1)
+            (func (export "add_from_memory") (result i32)
+                (i32.add
+                    (i32.load (i32.const 0))
+                    (i32.load (i32.const 4))))
+        )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    let memory = instance
+        .get_memory(&mut store, "memory")
+        .ok_or_else(|| anyhow!("memory export not found"))?;
+    let add = instance.get_typed_func::<(), i32>(&mut store, "add_from_memory")?;
+
+    let data = memory.data_mut(&mut store);
+    data[0..4].copy_from_slice(&17i32.to_le_bytes());
+    data[4..8].copy_from_slice(&25i32.to_le_bytes());
+
+    let result = add.call(&mut store, ())?;
+    println!("17 + 25 = {result}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_from_memory() -> Result<()> {
+        let engine = Engine::default();
+        let module = Module::new(
+            &engine,
+            r#"
+            (module
+                (memory (export "memory") 1)
+                (func (export "add_from_memory") (result i32)
+                    (i32.add
+                        (i32.load (i32.const 0))
+                        (i32.load (i32.const 4))))
+            )
+            "#,
+        )?;
+        let mut store = Store::new(&engine, ());
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .ok_or_else(|| anyhow!("memory export not found"))?;
+        let add = instance.get_typed_func::<(), i32>(&mut store, "add_from_memory")?;
+        let data = memory.data_mut(&mut store);
+        data[0..4].copy_from_slice(&10i32.to_le_bytes());
+        data[4..8].copy_from_slice(&32i32.to_le_bytes());
+        assert_eq!(add.call(&mut store, ())?, 42);
+        Ok(())
+    }
+}

--- a/crates/wasm_component_guest/Cargo.toml
+++ b/crates/wasm_component_guest/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "greeter"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[package.metadata.component]
+package = "example:greeter"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "0.43"

--- a/crates/wasm_component_guest/src/lib.rs
+++ b/crates/wasm_component_guest/src/lib.rs
@@ -1,0 +1,11 @@
+wit_bindgen::generate!({ world: "greeter" });
+
+struct Component;
+
+impl Guest for Component {
+    fn greet(name: String) -> String {
+        format!("Hello, {name}!")
+    }
+}
+
+export!(Component);

--- a/crates/wasm_component_guest/wit/world.wit
+++ b/crates/wasm_component_guest/wit/world.wit
@@ -1,0 +1,5 @@
+package example:greeter@0.1.0;
+
+world greeter {
+    export greet: func(name: string) -> string;
+}

--- a/crates/wasm_component_host/Cargo.toml
+++ b/crates/wasm_component_host/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasm-component-host"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+wasmtime = { version = "45", features = ["component-model"] }
+wasmtime-wasi = "45"

--- a/crates/wasm_component_host/src/main.rs
+++ b/crates/wasm_component_host/src/main.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use wasmtime::component::{bindgen, Component, Linker, ResourceTable};
+use wasmtime::{Config, Engine, Store};
+use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+bindgen!({
+    world: "greeter",
+    path: "../wasm_component_guest/wit/world.wit",
+});
+
+struct State {
+    table: ResourceTable,
+    wasi: WasiCtx,
+}
+
+impl WasiView for State {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.wasi,
+            table: &mut self.table,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+    let engine = Engine::new(&config)?;
+
+    let component = Component::from_file(
+        &engine,
+        "crates/wasm_component_guest/target/wasm32-wasip2/release/greeter.wasm",
+    )?;
+
+    let mut linker: Linker<State> = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker)?;
+
+    let wasi = WasiCtxBuilder::new().build();
+    let mut store = Store::new(&engine, State {
+        table: ResourceTable::new(),
+        wasi,
+    });
+
+    let greeter = Greeter::instantiate(&mut store, &component, &linker)?;
+    let message = greeter.call_greet(&mut store, "WebAssembly")?;
+    println!("{message}");
+    Ok(())
+}

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -81,3 +81,8 @@
     - [Downloads](web/clients/download.md)
     - [Web Authentication](web/clients/authentication.md)
   - [Full Stack Web](web/leptos.md)
+- [WebAssembly](wasm.md)
+  - [Call an exported function](wasm/call_export.md)
+  - [Exchange data via linear memory](wasm/linear_memory.md)
+  - [Define host functions](wasm/host_fn.md)
+  - [Component Model](wasm/component.md)

--- a/src/links.md
+++ b/src/links.md
@@ -51,6 +51,8 @@ Keep lines sorted.
 [cat-text-processing]: https://crates.io/categories/text-processing
 [cat-time-badge]: https://img.shields.io/badge/time--x.svg?style=social
 [cat-time]: https://crates.io/categories/date-and-time
+[cat-wasm-badge]: https://img.shields.io/badge/wasm--x.svg?style=social
+[cat-wasm]: https://crates.io/categories/wasm
 
 <!-- Crates -->
 
@@ -173,3 +175,9 @@ Keep lines sorted.
 [walkdir]: https://docs.rs/walkdir/
 [wasm-bindgen-badge]: https://img.shields.io/crates/v/wasm-bindgen.svg?label=wasm-bindgen
 [wasm-bindgen]: https://docs.rs/wasm-bindgen/
+[wasmtime-badge]: https://img.shields.io/crates/v/wasmtime.svg?label=wasmtime
+[wasmtime]: https://docs.rs/wasmtime/
+[wasmtime-wasi-badge]: https://img.shields.io/crates/v/wasmtime-wasi.svg?label=wasmtime-wasi
+[wasmtime-wasi]: https://docs.rs/wasmtime-wasi/
+[wit-bindgen-badge]: https://img.shields.io/crates/v/wit-bindgen.svg?label=wit-bindgen
+[wit-bindgen]: https://docs.rs/wit-bindgen/

--- a/src/wasm.md
+++ b/src/wasm.md
@@ -1,0 +1,26 @@
+# WebAssembly
+
+[`wasmtime`][wasmtime] is an embeddable WebAssembly runtime. These recipes
+cover the **host embedding API** — loading modules, calling exports, sharing
+linear memory, and wiring up host-defined functions that guests can call back
+into.
+
+The recipes live outside the main workspace because `wasmtime` is a large
+dependency not used elsewhere. Run them with
+`cargo run --manifest-path crates/wasm/Cargo.toml --bin <name>`.
+
+**Embedding wasmtime**
+
+| Recipe | Crates | Categories |
+|--------|--------|------------|
+| [Call an exported WebAssembly function][ex-wasm-call-export] | [![wasmtime-badge]][wasmtime] | [![cat-wasm-badge]][cat-wasm] |
+| [Exchange data via WebAssembly linear memory][ex-wasm-linear-memory] | [![wasmtime-badge]][wasmtime] | [![cat-wasm-badge]][cat-wasm] |
+| [Define host functions for WebAssembly][ex-wasm-host-fn] | [![wasmtime-badge]][wasmtime] | [![cat-wasm-badge]][cat-wasm] |
+| [Component Model — typed strings and structs][ex-wasm-component] | [![wasmtime-badge]][wasmtime] [![wasmtime-wasi-badge]][wasmtime-wasi] [![wit-bindgen-badge]][wit-bindgen] | [![cat-wasm-badge]][cat-wasm] |
+
+[ex-wasm-call-export]: wasm/call_export.html#call-an-exported-webassembly-function
+[ex-wasm-linear-memory]: wasm/linear_memory.html#exchange-data-via-webassembly-linear-memory
+[ex-wasm-host-fn]: wasm/host_fn.html#define-host-functions-for-webassembly
+[ex-wasm-component]: wasm/component.html#component-model--typed-strings-and-structs
+
+{{#include links.md}}

--- a/src/wasm/call_export.md
+++ b/src/wasm/call_export.md
@@ -1,0 +1,46 @@
+# Call an exported WebAssembly function
+
+[![wasmtime-badge]][wasmtime] [![cat-wasm-badge]][cat-wasm]
+
+[`wasmtime`][wasmtime] embeds a WebAssembly runtime inside a Rust host
+program. This recipe compiles a module from [WebAssembly Text format
+(WAT)][wat-spec], instantiates it, and calls an exported function.
+
+The three core types are [`Engine`][engine], which holds compiler settings;
+[`Module`][module], which holds compiled bytecode; and [`Store`][store], which
+holds all runtime state for a set of instances.
+
+[`Instance::new`][instance-new] links the compiled module with its imports
+(none here) and produces a live instance. [`get_typed_func`][get-typed-func]
+looks up an export by name and checks that its signature matches the Rust
+generic parameters — `(i32, i32)` in, `i32` out.
+
+Core WebAssembly function parameters are limited to four numeric types:
+`i32`, `i64`, `f32`, and `f64`. Strings, structs, and other complex values
+cannot cross the function boundary directly — see [Exchange data via linear
+memory][ex-wasm-linear-memory] for the pointer-and-length pattern, or the
+[Component Model][wasm-component-model] for a higher-level IDL that lifts
+these restrictions.
+
+[ex-wasm-linear-memory]: linear_memory.html#exchange-data-via-webassembly-linear-memory
+[wasm-component-model]: https://component-model.bytecodealliance.org/
+
+[engine]: https://docs.rs/wasmtime/*/wasmtime/struct.Engine.html
+[module]: https://docs.rs/wasmtime/*/wasmtime/struct.Module.html
+[store]: https://docs.rs/wasmtime/*/wasmtime/struct.Store.html
+[instance-new]: https://docs.rs/wasmtime/*/wasmtime/struct.Instance.html#method.new
+[get-typed-func]: https://docs.rs/wasmtime/*/wasmtime/struct.Instance.html#method.get_typed_func
+[wat-spec]: https://webassembly.github.io/spec/core/text/index.html
+
+```rust
+{{#include ../../crates/wasm/src/bin/call_export.rs::23}}
+```
+
+Run it:
+
+```shell
+cargo run --manifest-path crates/wasm/Cargo.toml --bin call_export
+# 5 + 37 = 42
+```
+
+{{#include ../links.md}}

--- a/src/wasm/component.md
+++ b/src/wasm/component.md
@@ -1,0 +1,75 @@
+# Component Model — typed strings and structs
+
+[![wasmtime-badge]][wasmtime] [![wasmtime-wasi-badge]][wasmtime-wasi] [![wit-bindgen-badge]][wit-bindgen] [![cat-wasm-badge]][cat-wasm]
+
+Core WebAssembly function parameters are limited to `i32`, `i64`, `f32`, and
+`f64`. The [WebAssembly Component Model][cm-spec] removes that restriction by
+adding a language-neutral interface description language called
+[WIT][wit-spec]. Strings, lists, records, and variants all become first-class
+types that cross the guest/host boundary without manual pointer arithmetic.
+
+[cm-spec]: https://component-model.bytecodealliance.org/
+[wit-spec]: https://component-model.bytecodealliance.org/design/wit.html
+
+This recipe requires two extra tools:
+
+```shell
+cargo install cargo-component
+rustup target add wasm32-wasip2
+```
+
+## Define the interface in WIT
+
+A WIT *world* declares what a component exports and imports. This one exports a
+single `greet` function that takes and returns a `string`.
+
+```wit
+{{#include ../../crates/wasm_component_guest/wit/world.wit}}
+```
+
+## Implement the guest
+
+[`wit_bindgen::generate!`][wit-bindgen-generate] reads the WIT file at compile
+time and emits a `Guest` trait. The concrete type `Component` implements it,
+and [`export!`][wit-bindgen-export] wires it up as the component's entry point.
+
+[wit-bindgen-generate]: https://docs.rs/wit-bindgen/*/wit_bindgen/macro.generate.html
+[wit-bindgen-export]: https://docs.rs/wit-bindgen/*/wit_bindgen/macro.export.html
+
+```rust,ignore
+{{#include ../../crates/wasm_component_guest/src/lib.rs}}
+```
+
+Build the guest into a `.wasm` component:
+
+```shell
+cd crates/wasm_component_guest
+cargo component build --release
+```
+
+## Run it from the host
+
+The host uses [`wasmtime::component::bindgen!`][bindgen-macro] — the same WIT
+file, read at compile time — to generate a typed `Greeter` wrapper. [`Config`]
+enables the component model, [`wasmtime_wasi::p2::add_to_linker_sync`] wires
+up WASI Preview 2 (required even for guests that don't use WASI directly), and
+[`Greeter::instantiate`] produces a handle whose `call_greet` method accepts a
+`&str` and returns a `String`.
+
+[bindgen-macro]: https://docs.rs/wasmtime/*/wasmtime/component/macro.bindgen.html
+[`Config`]: https://docs.rs/wasmtime/*/wasmtime/struct.Config.html
+[`wasmtime_wasi::p2::add_to_linker_sync`]: https://docs.rs/wasmtime-wasi/*/wasmtime_wasi/p2/fn.add_to_linker_sync.html
+[`Greeter::instantiate`]: https://docs.rs/wasmtime/*/wasmtime/component/struct.Instance.html
+
+```rust,ignore
+{{#include ../../crates/wasm_component_host/src/main.rs}}
+```
+
+Run from the repo root (after building the guest):
+
+```shell
+cargo run --manifest-path crates/wasm_component_host/Cargo.toml
+# Hello, WebAssembly!
+```
+
+{{#include ../links.md}}

--- a/src/wasm/component.md
+++ b/src/wasm/component.md
@@ -44,7 +44,7 @@ Build the guest into a `.wasm` component:
 
 ```shell
 cd crates/wasm_component_guest
-cargo component build --release
+cargo component build --release --target wasm32-wasip2
 ```
 
 ## Run it from the host

--- a/src/wasm/component.md
+++ b/src/wasm/component.md
@@ -33,8 +33,8 @@ single `greet` function that takes and returns a `string`.
 time and emits a `Guest` trait. The concrete type `Component` implements it,
 and [`export!`][wit-bindgen-export] wires it up as the component's entry point.
 
-[wit-bindgen-generate]: https://docs.rs/wit-bindgen/*/wit_bindgen/macro.generate.html
-[wit-bindgen-export]: https://docs.rs/wit-bindgen/*/wit_bindgen/macro.export.html
+[wit-bindgen-generate]: https://docs.rs/wit-bindgen/latest/wit_bindgen/macro.generate.html
+[wit-bindgen-export]: https://docs.rs/wit-bindgen/latest/wit_bindgen/macro.generate.html#exports-the-export-macro
 
 ```rust,ignore
 {{#include ../../crates/wasm_component_guest/src/lib.rs}}

--- a/src/wasm/host_fn.md
+++ b/src/wasm/host_fn.md
@@ -1,0 +1,35 @@
+# Define host functions for WebAssembly
+
+[![wasmtime-badge]][wasmtime] [![cat-wasm-badge]][cat-wasm]
+
+WebAssembly modules can import functions from the host, enabling guests to
+call back into Rust. This recipe defines a `print` function in the host that
+the WASM guest calls to write a message stored in its own linear memory.
+
+[`Func::wrap`][func-wrap] creates a host-defined function from a Rust closure.
+The first parameter is a [`Caller`][caller] — a handle to the calling
+instance's store. The guest module declares the import with
+`(import "host" "print" ...)` and the host passes `[print_fn.into()]` as the
+imports slice to [`Instance::new`][instance-new].
+
+Inside the closure, [`Caller::get_export`][get-export] retrieves the guest's
+`memory` export so the host can read the bytes the guest passed by pointer and
+length.
+
+[func-wrap]: https://docs.rs/wasmtime/*/wasmtime/struct.Func.html#method.wrap
+[caller]: https://docs.rs/wasmtime/*/wasmtime/struct.Caller.html
+[instance-new]: https://docs.rs/wasmtime/*/wasmtime/struct.Instance.html#method.new
+[get-export]: https://docs.rs/wasmtime/*/wasmtime/struct.Caller.html#method.get_export
+
+```rust
+{{#include ../../crates/wasm/src/bin/host_fn.rs::38}}
+```
+
+Run it:
+
+```shell
+cargo run --manifest-path crates/wasm/Cargo.toml --bin host_fn
+# [wasm] Hello from WebAssembly!
+```
+
+{{#include ../links.md}}

--- a/src/wasm/host_fn.md
+++ b/src/wasm/host_fn.md
@@ -12,9 +12,15 @@ instance's store. The guest module declares the import with
 `(import "host" "print" ...)` and the host passes `[print_fn.into()]` as the
 imports slice to [`Instance::new`][instance-new].
 
+[`Instance::new`][instance-new] takes `&[Extern]` — the enum that can hold a
+[`Func`][func-type], `Memory`, `Global`, or `Table`. `.into()` converts the
+`Func` into an `Extern` so the slice type is satisfied.
+
 Inside the closure, [`Caller::get_export`][get-export] retrieves the guest's
 `memory` export so the host can read the bytes the guest passed by pointer and
 length.
+
+[func-type]: https://docs.rs/wasmtime/*/wasmtime/struct.Func.html
 
 [func-wrap]: https://docs.rs/wasmtime/*/wasmtime/struct.Func.html#method.wrap
 [caller]: https://docs.rs/wasmtime/*/wasmtime/struct.Caller.html

--- a/src/wasm/linear_memory.md
+++ b/src/wasm/linear_memory.md
@@ -1,0 +1,30 @@
+# Exchange data via WebAssembly linear memory
+
+[![wasmtime-badge]][wasmtime] [![cat-wasm-badge]][cat-wasm]
+
+WebAssembly modules communicate with their host through [linear
+memory][linear-memory-spec] — a flat, byte-addressable array that both sides
+can read and write. This recipe writes two `i32` values into the WASM module's
+memory, calls a function that adds them, and reads the result back from the
+return value.
+
+[`get_memory`][get-memory] retrieves the module's exported `memory` object.
+[`data_mut`][data-mut] gives a mutable byte slice covering the entire linear
+memory so the host can write inputs before the call.
+
+[linear-memory-spec]: https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances
+[get-memory]: https://docs.rs/wasmtime/*/wasmtime/struct.Instance.html#method.get_memory
+[data-mut]: https://docs.rs/wasmtime/*/wasmtime/struct.Memory.html#method.data_mut
+
+```rust
+{{#include ../../crates/wasm/src/bin/linear_memory.rs::33}}
+```
+
+Run it:
+
+```shell
+cargo run --manifest-path crates/wasm/Cargo.toml --bin linear_memory
+# 17 + 25 = 42
+```
+
+{{#include ../links.md}}


### PR DESCRIPTION
## Summary

Closes #764

Adds a new top-level **WebAssembly** section covering `wasmtime` as an embeddable host runtime — the portable compute / plugin use case, distinct from the existing browser-targeting Leptos recipes.

- **Call an exported function** — compile a WAT module inline, instantiate it, call a typed export (`get_typed_func`)
- **Exchange data via linear memory** — write `i32` values into WASM linear memory from the host, read result back via return value
- **Define host functions** — Rust closure the WASM guest can call back into (`Func::wrap`, `Caller::get_export`)
- **Component Model** (`no_run`) — WIT-defined interface with `wasmtime-wasi` p2 + `wit-bindgen`; strings cross the boundary without pointer arithmetic; requires `cargo-component` + `wasm32-wasip2`

The `call_export` recipe also documents the core WASM numeric-type restriction (`i32`/`i64`/`f32`/`f64` only) and cross-links to the linear memory and Component Model recipes.

All four recipes use the standalone crate pattern under `crates/wasm*` and are excluded from skeptic via `REMOVED_PREFIXES`.

## Test plan

- [x] `cargo test -p wasm` — 3 tests pass (call_export, linear_memory, host_fn)
- [x] `cargo test --test skeptic` — pre-existing failures only, no regressions
- [x] `mdbook build` — clean, no include errors
- [x] Component Model end-to-end:
  ```shell
  cargo install cargo-component
  rustup target add wasm32-wasip2
  cargo component build --release --target wasm32-wasip2 --manifest-path crates/wasm_component_guest/Cargo.toml
  cargo run --manifest-path crates/wasm_component_host/Cargo.toml
  # Hello, WebAssembly!
  ```
<img width="634" height="109" alt="image" src="https://github.com/user-attachments/assets/704fe7ea-65d9-46dc-9036-6a2d8409a416" />

🤖 Generated with [Claude Code](https://claude.ai/claude-code)