### PR TITLE
Add WebAssembly to intro.md TOC; document in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ When a dependency version needs to change, migrate the affected examples rather 
 - Mark examples needing external services with `no_run`
 - Hide boilerplate with `# ` prefix (hidden from book, visible to skeptic)
 - Prefer creating standalone crates for new examples over adding dependencies to root `Cargo.toml`
+- When adding a **new top-level section** (`src/<section>.md`), also add `{{#include <section>.md}}` to `src/intro.md` in the correct alphabetical position — that file is the book's table of contents page
 
 ## Pull Request Checklist
 

--- a/src/intro.md
+++ b/src/intro.md
@@ -52,6 +52,8 @@ community. It needs and welcomes help. For details see
 
 {{#include text.md}}
 
+{{#include wasm.md}}
+
 {{#include web.md}}
 
 


### PR DESCRIPTION
## Summary

- Adds `{{#include wasm.md}}` to `src/intro.md` between `text.md` and `web.md`, restoring the WebAssembly section to the book's table-of-contents page (missing after #783 merged)
- Adds a note to `CLAUDE.md` → Writing Examples: new top-level sections must also be added to `src/intro.md`

## Test plan

- [ ] `mdbook build` renders the WebAssembly section in the intro/TOC page
- [ ] Entry appears in correct alphabetical position (between Text Processing and Web Programming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)