### PR TITLE
Add std::collections recipes as a Data Structures subsection

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -40,10 +40,14 @@ Backtrace
 BACKTRACE
 BeforePath
 bindgen
+BinaryHeap
+binaryheap
 bitfield
 bitflags
 bitwise
 bool
+BTreeMap
+btreemap
 BufRead
 BufReader
 byteorder
@@ -133,7 +137,9 @@ Hackerman
 handleactormessage
 hardcoded
 Hardcoded
+hashmap
 HashMap
+hashset
 HashSet
 hashtag
 HASHTAG
@@ -359,6 +365,8 @@ UserAgent
 userid
 usize
 VarError
+VecDeque
+vecdeque
 versa
 versioning
 Versioning

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,6 +28,7 @@
   - [Encryption](cryptography/encryption.md)
 - [Data Structures](data_structures.md)
   - [Bitfield](data_structures/bitfield.md)
+  - [Collections](data_structures/collections.md)
 - [Database](database.md)
   - [SQLite](database/sqlite.md)
   - [Postgres](database/postgres.md)

--- a/src/data_structures.md
+++ b/src/data_structures.md
@@ -3,7 +3,19 @@
 | Recipe | Crates | Categories |
 |--------|--------|------------|
 | [Define and operate on a type represented as a bitfield][ex-bitflags] | [![bitflags-badge]][bitflags] | [![cat-no-std-badge]][cat-no-std] |
+| [Count word frequency in a document][ex-hashmap-entry] | [![std-badge]][std] | [![cat-data-structures-badge]][cat-data-structures] |
+| [Group records by key][ex-hashmap-group] | [![std-badge]][std] | [![cat-data-structures-badge]][cat-data-structures] |
+| [Look up records within a time range][ex-btreemap-range] | [![std-badge]][std] | [![cat-data-structures-badge]][cat-data-structures] |
+| [Set operations with HashSet][ex-hashset-ops] | [![std-badge]][std] | [![cat-data-structures-badge]][cat-data-structures] |
+| [Process tasks in priority order][ex-binaryheap] | [![std-badge]][std] | [![cat-data-structures-badge]][cat-data-structures] |
+| [Sliding-window buffer with VecDeque][ex-vecdeque] | [![std-badge]][std] | [![cat-data-structures-badge]][cat-data-structures] |
 
 [ex-bitflags]: data_structures/bitfield.html#define-and-operate-on-a-type-represented-as-a-bitfield
+[ex-hashmap-entry]: data_structures/collections.html#count-word-frequency-in-a-document
+[ex-hashmap-group]: data_structures/collections.html#group-records-by-key
+[ex-btreemap-range]: data_structures/collections.html#look-up-records-within-a-time-range
+[ex-hashset-ops]: data_structures/collections.html#set-operations-with-hashset
+[ex-binaryheap]: data_structures/collections.html#process-tasks-in-priority-order
+[ex-vecdeque]: data_structures/collections.html#sliding-window-buffer-with-vecdeque
 
 {{#include links.md}}

--- a/src/data_structures/collections.md
+++ b/src/data_structures/collections.md
@@ -1,0 +1,10 @@
+# Collections
+
+{{#include collections/hashmap-entry.md}}
+{{#include collections/hashmap-group.md}}
+{{#include collections/btreemap-range.md}}
+{{#include collections/hashset-ops.md}}
+{{#include collections/binaryheap.md}}
+{{#include collections/vecdeque.md}}
+
+{{#include ../links.md}}

--- a/src/data_structures/collections/binaryheap.md
+++ b/src/data_structures/collections/binaryheap.md
@@ -1,0 +1,40 @@
+## Process Tasks in Priority Order
+
+[![std-badge]][std] [![cat-data-structures-badge]][cat-data-structures]
+
+Uses [`BinaryHeap`] as a max-priority queue: [`push`] inserts an item and [`pop`] always removes the highest-priority one first. Wrapping items in [`Reverse`] turns it into a min-priority queue without a custom comparator.
+
+```rust,edition2021
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+fn main() {
+    // Max-heap: highest priority number is processed first
+    let mut queue: BinaryHeap<(u32, &str)> = BinaryHeap::new();
+    queue.push((3, "send report"));
+    queue.push((1, "check email"));
+    queue.push((5, "fix production bug"));
+    queue.push((2, "review PR"));
+
+    println!("Max-heap — processing order:");
+    while let Some((priority, task)) = queue.pop() {
+        println!("  [{priority}] {task}");
+    }
+
+    // Min-heap: wrap with Reverse so lowest number is processed first
+    let mut min_queue: BinaryHeap<Reverse<(u32, &str)>> = BinaryHeap::new();
+    min_queue.push(Reverse((3, "send report")));
+    min_queue.push(Reverse((1, "check email")));
+    min_queue.push(Reverse((5, "fix production bug")));
+
+    println!("Min-heap — processing order:");
+    while let Some(Reverse((priority, task))) = min_queue.pop() {
+        println!("  [{priority}] {task}");
+    }
+}
+```
+
+[`BinaryHeap`]: https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html
+[`push`]: https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#method.push
+[`pop`]: https://doc.rust-lang.org/std/collections/struct.BinaryHeap.html#method.pop
+[`Reverse`]: https://doc.rust-lang.org/std/cmp/struct.Reverse.html

--- a/src/data_structures/collections/btreemap-range.md
+++ b/src/data_structures/collections/btreemap-range.md
@@ -1,0 +1,31 @@
+## Look Up Records Within a Time Range
+
+[![std-badge]][std] [![cat-data-structures-badge]][cat-data-structures]
+
+Stores timestamped sensor readings in a [`BTreeMap`], which keeps keys in sorted order using a B-tree structure. [`BTreeMap::range`] locates the start of the range with binary search in O(log n) time and then iterates forward — so the cost scales with the result size, not the total number of entries. A `HashMap` cannot do this at all; it has no ordering to exploit.
+
+```rust,edition2021
+use std::collections::BTreeMap;
+
+fn main() {
+    let mut readings: BTreeMap<u32, f64> = BTreeMap::new();
+    readings.insert(1_000, 20.1);
+    readings.insert(2_000, 21.3);
+    readings.insert(3_000, 19.8);
+    readings.insert(4_000, 22.5);
+    readings.insert(5_000, 23.1);
+
+    let window: Vec<(&u32, &f64)> = readings.range(2_000..=4_000).collect();
+    println!("Readings from t=2000 to t=4000:");
+    for (ts, temp) in &window {
+        println!("  t={ts:>5}  {temp:.1}°C");
+    }
+
+    assert_eq!(window.len(), 3);
+    assert_eq!(*window[0].0, 2_000);
+    assert_eq!(*window[2].0, 4_000);
+}
+```
+
+[`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
+[`BTreeMap::range`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html#method.range

--- a/src/data_structures/collections/hashmap-entry.md
+++ b/src/data_structures/collections/hashmap-entry.md
@@ -1,0 +1,39 @@
+## Count Word Frequency in a Document
+
+[![std-badge]][std] [![cat-data-structures-badge]][cat-data-structures]
+
+Splits a string into words with [`split_whitespace`] and counts each word's occurrences. [`HashMap::entry`] with [`or_insert`] initializes a missing key to zero and returns a mutable reference, so the increment requires no separate lookup. [`sort_by_key`] with [`Reverse`] sorts the results descending by count; wrapping the count in `Reverse` flips the natural ascending order without a manual comparator.
+
+```rust,edition2021
+use std::cmp::Reverse;
+use std::collections::HashMap;
+
+fn word_count(text: &str) -> HashMap<&str, usize> {
+    let mut counts = HashMap::new();
+    for word in text.split_whitespace() {
+        *counts.entry(word).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn main() {
+    let text = "the quick brown fox jumps over the lazy dog the fox";
+    let counts = word_count(text);
+
+    let mut pairs: Vec<(&str, usize)> = counts.iter().map(|(&w, &c)| (w, c)).collect();
+    pairs.sort_by_key(|&(word, count)| (Reverse(count), word));
+    for (word, count) in &pairs {
+        println!("{word:>12}  {count}");
+    }
+
+    assert_eq!(counts["the"], 3);
+    assert_eq!(counts["fox"], 2);
+    assert_eq!(counts["quick"], 1);
+}
+```
+
+[`split_whitespace`]: https://doc.rust-lang.org/std/primitive.str.html#method.split_whitespace
+[`HashMap::entry`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry
+[`or_insert`]: https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.or_insert
+[`sort_by_key`]: https://doc.rust-lang.org/std/primitive.slice.html#method.sort_by_key
+[`Reverse`]: https://doc.rust-lang.org/std/cmp/struct.Reverse.html

--- a/src/data_structures/collections/hashmap-group.md
+++ b/src/data_structures/collections/hashmap-group.md
@@ -1,0 +1,43 @@
+## Group Records by Key
+
+[![std-badge]][std] [![cat-data-structures-badge]][cat-data-structures]
+
+Groups a flat list of records into a [`HashMap`] of vectors using [`entry`] with [`or_default`], which inserts an empty `Vec` the first time a key is seen and returns a mutable reference to it on every call. [`keys`] with [`copied`] produces an owned `Vec<&str>` for sorting — `copied` turns the `&&str` references that `keys` yields into `&str` values.
+
+```rust,edition2021
+use std::collections::HashMap;
+
+fn main() {
+    let log_lines = vec![
+        ("ERROR", "disk full"),
+        ("WARN",  "high memory usage"),
+        ("INFO",  "server started"),
+        ("ERROR", "connection refused"),
+        ("INFO",  "request received"),
+    ];
+
+    let mut by_level: HashMap<&str, Vec<&str>> = HashMap::new();
+    for (level, message) in log_lines {
+        by_level.entry(level).or_default().push(message);
+    }
+
+    let mut levels: Vec<&str> = by_level.keys().copied().collect();
+    levels.sort();
+    for level in levels {
+        println!("[{level}]");
+        for msg in &by_level[level] {
+            println!("  {msg}");
+        }
+    }
+
+    assert_eq!(by_level["ERROR"].len(), 2);
+    assert_eq!(by_level["INFO"].len(), 2);
+    assert_eq!(by_level["WARN"].len(), 1);
+}
+```
+
+[`HashMap`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html
+[`entry`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.entry
+[`or_default`]: https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.or_default
+[`keys`]: https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.keys
+[`copied`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.copied

--- a/src/data_structures/collections/hashset-ops.md
+++ b/src/data_structures/collections/hashset-ops.md
@@ -1,0 +1,44 @@
+## Set Operations with HashSet
+
+[![std-badge]][std] [![cat-data-structures-badge]][cat-data-structures]
+
+Computes the [`difference`], [`intersection`], and [`union`] of two [`HashSet`]s. Each operation returns an iterator of references; [`copied`] converts `&&str` to `&str` for easier collection.
+
+```rust,edition2021
+use std::collections::HashSet;
+
+fn main() {
+    let deployed: HashSet<&str> = ["web", "api", "worker", "scheduler"]
+        .iter()
+        .copied()
+        .collect();
+    let monitored: HashSet<&str> = ["web", "api", "database"]
+        .iter()
+        .copied()
+        .collect();
+
+    // Services running but not being monitored
+    let mut unmonitored: Vec<&str> = deployed.difference(&monitored).copied().collect();
+    unmonitored.sort();
+    println!("Deployed but not monitored: {unmonitored:?}");
+    assert_eq!(unmonitored, ["scheduler", "worker"]);
+
+    // Services present in both sets
+    let mut common: Vec<&str> = deployed.intersection(&monitored).copied().collect();
+    common.sort();
+    println!("Monitored and deployed:     {common:?}");
+    assert_eq!(common, ["api", "web"]);
+
+    // All services mentioned across both sets
+    let mut all: Vec<&str> = deployed.union(&monitored).copied().collect();
+    all.sort();
+    println!("All services:               {all:?}");
+    assert_eq!(all.len(), 5);
+}
+```
+
+[`HashSet`]: https://doc.rust-lang.org/std/collections/struct.HashSet.html
+[`difference`]: https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.difference
+[`intersection`]: https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.intersection
+[`union`]: https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.union
+[`copied`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.copied

--- a/src/data_structures/collections/vecdeque.md
+++ b/src/data_structures/collections/vecdeque.md
@@ -1,0 +1,45 @@
+## Sliding-Window Buffer with VecDeque
+
+[![std-badge]][std] [![cat-data-structures-badge]][cat-data-structures]
+
+Maintains a fixed-size window over a stream of values using [`VecDeque`]. [`push_back`] appends new values and [`pop_front`] discards the oldest, keeping memory bounded regardless of input length. [`with_capacity`] is optional — `VecDeque::new()` works fine — but pre-allocating the window size avoids reallocations as the buffer fills up for the first time. [`zip`] pairs each original reading with its computed average for display.
+
+```rust,edition2021
+use std::collections::VecDeque;
+
+fn sliding_average(values: &[f64], window: usize) -> Vec<f64> {
+    let mut buf: VecDeque<f64> = VecDeque::with_capacity(window);
+    let mut averages = Vec::with_capacity(values.len());
+
+    for &v in values {
+        if buf.len() == window {
+            buf.pop_front();
+        }
+        buf.push_back(v);
+        averages.push(buf.iter().sum::<f64>() / buf.len() as f64);
+    }
+    averages
+}
+
+fn main() {
+    let readings = [1.0, 2.0, 3.0, 4.0, 5.0];
+    let averages = sliding_average(&readings, 3);
+
+    println!("reading  average");
+    for (r, a) in readings.iter().zip(&averages) {
+        println!("  {r:.1}      {a:.2}");
+    }
+
+    assert_eq!(averages[0], 1.0);  // window: [1.0]
+    assert_eq!(averages[1], 1.5);  // window: [1.0, 2.0]
+    assert_eq!(averages[2], 2.0);  // window: [1.0, 2.0, 3.0]
+    assert_eq!(averages[3], 3.0);  // window: [2.0, 3.0, 4.0]
+    assert_eq!(averages[4], 4.0);  // window: [3.0, 4.0, 5.0]
+}
+```
+
+[`VecDeque`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html
+[`with_capacity`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.with_capacity
+[`push_back`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.push_back
+[`pop_front`]: https://doc.rust-lang.org/std/collections/struct.VecDeque.html#method.pop_front
+[`zip`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.zip


### PR DESCRIPTION
## Summary

- Adds a `Collections` subsection under Data Structures with six recipes covering `std::collections`
- Each recipe frames a real problem rather than an API tour, includes `println!` output, and links all mentioned identifiers to `doc.rust-lang.org`

## Recipes added

| Recipe | Collection |
|--------|------------|
| Count word frequency in a document | `HashMap` entry API with `or_insert` |
| Group records by key | `HashMap` with `entry().or_default()` |
| Look up records within a time range | `BTreeMap::range` (O(log n) binary search) |
| Set operations | `HashSet` difference, intersection, union |
| Process tasks in priority order | `BinaryHeap` max-heap and `Reverse` min-heap |
| Sliding-window buffer | `VecDeque` push_back / pop_front |

## Test plan

- [x] `cargo test --test skeptic` passes (167 tests, 0 failures)
- [x] All six new test cases included in the passing count
- [x] No `unwrap` — error handling per cookbook conventions
- [x] `[![std-badge]][std]` badge on all recipes
- [x] Identifier links use `doc.rust-lang.org/std/...`

fixes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)