### PR TITLE
Add std::path and basic filesystem operation recipes

### DIFF
--- a/src/file.md
+++ b/src/file.md
@@ -2,9 +2,14 @@
 
 | Recipe | Crates | Categories |
 |--------|--------|------------|
+| [Read a whole file into a string][ex-read-to-string] | [![std-badge]][std] [![tempfile-badge]][tempfile] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Write a string to a file][ex-write-string] | [![std-badge]][std] [![tempfile-badge]][tempfile] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Read lines of strings from a file][ex-std-read-lines] | [![std-badge]][std] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Rename or atomically replace a file][ex-rename] | [![std-badge]][std] [![tempfile-badge]][tempfile] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Avoid writing and reading from a same file][ex-avoid-read-write] | [![same_file-badge]][same_file] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Access a file randomly using a memory map][ex-random-file-access] | [![memmap-badge]][memmap] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Construct and inspect a path][ex-path-inspect] | [![std-badge]][std] | [![cat-filesystem-badge]][cat-filesystem] |
+| [Create a nested directory tree][ex-create-dir-all] | [![std-badge]][std] [![tempfile-badge]][tempfile] | [![cat-filesystem-badge]][cat-filesystem] |
 | [File names that have been modified in the last 24 hours][ex-file-24-hours-modified] | [![std-badge]][std] | [![cat-filesystem-badge]][cat-filesystem] [![cat-os-badge]][cat-os] |
 | [Find loops for a given path][ex-find-file-loops] | [![same_file-badge]][same_file] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Recursively find duplicate file names][ex-dedup-filenames] | [![walkdir-badge]][walkdir] | [![cat-filesystem-badge]][cat-filesystem] |
@@ -14,16 +19,21 @@
 | [Find all png files recursively][ex-glob-recursive] | [![glob-badge]][glob] | [![cat-filesystem-badge]][cat-filesystem] |
 | [Find all files with given pattern ignoring filename case][ex-glob-with] | [![glob-badge]][glob] | [![cat-filesystem-badge]][cat-filesystem] |
 
-[ex-std-read-lines]: file/read-write.html#read-lines-of-strings-from-a-file
 [ex-avoid-read-write]: file/read-write.html#avoid-writing-and-reading-from-a-same-file
-[ex-random-file-access]: file/read-write.html#access-a-file-randomly-using-a-memory-map
-[ex-file-24-hours-modified]: file/dir.html#file-names-that-have-been-modified-in-the-last-24-hours
-[ex-find-file-loops]: file/dir.html#find-loops-for-a-given-path
+[ex-create-dir-all]: file/dir.html#create-a-nested-directory-tree
 [ex-dedup-filenames]: file/dir.html#recursively-find-duplicate-file-names
+[ex-file-24-hours-modified]: file/dir.html#file-names-that-have-been-modified-in-the-last-24-hours
 [ex-file-predicate]: file/dir.html#recursively-find-all-files-with-given-predicate
-[ex-file-skip-dot]: file/dir.html#traverse-directories-while-skipping-dotfiles
 [ex-file-sizes]: file/dir.html#recursively-calculate-file-sizes-at-given-depth
+[ex-file-skip-dot]: file/dir.html#traverse-directories-while-skipping-dotfiles
+[ex-find-file-loops]: file/dir.html#find-loops-for-a-given-path
 [ex-glob-recursive]: file/dir.html#find-all-png-files-recursively
 [ex-glob-with]: file/dir.html#find-all-files-with-given-pattern-ignoring-filename-case
+[ex-path-inspect]: file/dir.html#construct-and-inspect-a-path
+[ex-random-file-access]: file/read-write.html#access-a-file-randomly-using-a-memory-map
+[ex-read-to-string]: file/read-write.html#read-a-whole-file-into-a-string
+[ex-rename]: file/read-write.html#rename-or-atomically-replace-a-file
+[ex-std-read-lines]: file/read-write.html#read-lines-of-strings-from-a-file
+[ex-write-string]: file/read-write.html#write-a-string-to-a-file
 
 {{#include links.md}}

--- a/src/file/dir.md
+++ b/src/file/dir.md
@@ -1,5 +1,9 @@
 # Directory Traversal
 
+{{#include dir/path.md}}
+
+{{#include dir/create-dir-all.md}}
+
 {{#include dir/modified.md}}
 
 {{#include dir/loops.md}}

--- a/src/file/dir/create-dir-all.md
+++ b/src/file/dir/create-dir-all.md
@@ -1,0 +1,42 @@
+## Create a nested directory tree
+
+[![std-badge]][std] [![tempfile-badge]][tempfile] [![cat-filesystem-badge]][cat-filesystem]
+
+[`fs::create_dir_all`] is `mkdir -p`: it walks the requested path and creates
+every missing intermediate directory. It's idempotent — calling it on a path
+that already exists returns `Ok(())`, not an error — so it's the right call
+when seeding cache directories or log roots on startup.
+
+[`fs::create_dir`] only creates the final component. If any parent on the way
+is missing it fails with [`io::ErrorKind::NotFound`]. Reach for `create_dir`
+when the parent is known to exist and you want the operation to fail loudly
+if your assumption is wrong.
+
+```rust,edition2021
+use std::fs;
+use std::io;
+use tempfile::tempdir;
+
+fn main() -> io::Result<()> {
+    let root = tempdir()?;
+    let nested = root.path().join("cache").join("2026").join("05");
+
+    // Creates every missing component along the way.
+    fs::create_dir_all(&nested)?;
+    assert!(nested.is_dir());
+
+    // Calling it again on an existing directory is not an error.
+    fs::create_dir_all(&nested)?;
+
+    // `create_dir` only creates the leaf, and only when the parent exists.
+    let leaf = nested.join("26");
+    fs::create_dir(&leaf)?;
+    assert!(leaf.is_dir());
+
+    Ok(())
+}
+```
+
+[`fs::create_dir`]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
+[`fs::create_dir_all`]: https://doc.rust-lang.org/std/fs/fn.create_dir_all.html
+[`io::ErrorKind::NotFound`]: https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.NotFound

--- a/src/file/dir/path.md
+++ b/src/file/dir/path.md
@@ -1,0 +1,51 @@
+## Construct and inspect a path
+
+[![std-badge]][std] [![cat-filesystem-badge]][cat-filesystem]
+
+Most filesystem code is path arithmetic before it touches the disk. [`PathBuf`]
+owns the buffer; [`Path`] is the borrowed view. The inspection methods —
+[`file_name`], [`file_stem`], [`extension`], [`parent`] — return `Option`
+because a path might not have the component you ask for.
+
+[`PathBuf::push`] grows the buffer one component at a time. [`with_extension`]
+and [`with_file_name`] derive sibling or backup paths in one call without
+mutating the original. Conversion to `&str` goes through [`Path::to_str`],
+which returns `None` on non-UTF-8 paths.
+
+```rust,edition2021
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let mut path = PathBuf::from("/etc/nginx");
+    path.push("sites-available");
+    path.push("default.conf");
+
+    assert_eq!(path.parent(), Some(Path::new("/etc/nginx/sites-available")));
+    assert_eq!(path.file_name(), Some(OsStr::new("default.conf")));
+    assert_eq!(path.file_stem(), Some(OsStr::new("default")));
+    assert_eq!(path.extension(), Some(OsStr::new("conf")));
+
+    // Derive a backup name and a sibling path without mutating `path`.
+    let backup = path.with_extension("conf.bak");
+    assert_eq!(backup.file_name(), Some(OsStr::new("default.conf.bak")));
+
+    let sibling = path.with_file_name("nginx.conf");
+    assert_eq!(sibling, Path::new("/etc/nginx/sites-available/nginx.conf"));
+
+    // Borrow a `Path` as `&str` for APIs that need one.
+    let s: &str = path.to_str().expect("path is valid UTF-8");
+    println!("{s}");
+}
+```
+
+[`Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
+[`Path::to_str`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.to_str
+[`PathBuf`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
+[`PathBuf::push`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.push
+[`extension`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.extension
+[`file_name`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name
+[`file_stem`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.file_stem
+[`parent`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.parent
+[`with_extension`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.with_extension
+[`with_file_name`]: https://doc.rust-lang.org/std/path/struct.Path.html#method.with_file_name

--- a/src/file/read-write.md
+++ b/src/file/read-write.md
@@ -1,6 +1,12 @@
 # Read & Write
 
+{{#include read-write/read-string.md}}
+
+{{#include read-write/write-string.md}}
+
 {{#include read-write/read-file.md}}
+
+{{#include read-write/rename.md}}
 
 {{#include read-write/same-file.md}}
 

--- a/src/file/read-write/read-string.md
+++ b/src/file/read-write/read-string.md
@@ -1,0 +1,36 @@
+## Read a whole file into a string
+
+[![std-badge]][std] [![tempfile-badge]][tempfile] [![cat-filesystem-badge]][cat-filesystem]
+
+[`fs::read_to_string`] opens the file, reads it to end, closes it, and returns
+a [`String`] — one call for the common case of loading a small text file in
+full. It sizes the buffer from the file's length up front, so the read is a
+single allocation plus a single syscall loop.
+
+For files large enough that loading them whole would waste memory, switch to a
+[`BufReader`] over [`File::open`] and stream lines or bytes. The cutoff is
+workload-specific; past a few megabytes, the streaming form is usually the
+right choice.
+
+```rust,edition2021
+use std::fs;
+use std::io;
+use tempfile::tempdir;
+
+fn main() -> io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("config.toml");
+    fs::write(&path, "name = \"cookbook\"\nedition = 2021\n")?;
+
+    // One call: open, read, close.
+    let contents = fs::read_to_string(&path)?;
+    assert!(contents.contains("cookbook"));
+    println!("{contents}");
+    Ok(())
+}
+```
+
+[`BufReader`]: https://doc.rust-lang.org/std/io/struct.BufReader.html
+[`File::open`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.open
+[`String`]: https://doc.rust-lang.org/std/string/struct.String.html
+[`fs::read_to_string`]: https://doc.rust-lang.org/std/fs/fn.read_to_string.html

--- a/src/file/read-write/rename.md
+++ b/src/file/read-write/rename.md
@@ -1,0 +1,40 @@
+## Rename or atomically replace a file
+
+[![std-badge]][std] [![tempfile-badge]][tempfile] [![cat-filesystem-badge]][cat-filesystem]
+
+[`fs::rename`] is the atomic-replace primitive when source and destination
+live on the same filesystem: on Unix it's a single `rename(2)` syscall, on
+Windows it's `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`. A concurrent
+reader either opens the old contents or the new — never a half-written file,
+never a window where the path is missing.
+
+The write-to-temp-then-rename pattern below is how editors, package managers,
+and config writers avoid leaving a torn file behind if the process dies
+mid-write. The staging file and the final path must live on the same
+filesystem; across devices the kernel has no atomic move, and `rename` fails
+instead of silently degrading to a copy.
+
+```rust,edition2021
+use std::fs;
+use std::io;
+use tempfile::tempdir;
+
+fn main() -> io::Result<()> {
+    let dir = tempdir()?;
+    let final_path = dir.path().join("config.toml");
+    let staging = dir.path().join("config.toml.new");
+
+    // Write the new contents to a sibling path first...
+    fs::write(&staging, "version = 2\n")?;
+
+    // ...then swap it into place. Readers see either the old file or the
+    // new one, never a partial write.
+    fs::rename(&staging, &final_path)?;
+
+    assert_eq!(fs::read_to_string(&final_path)?, "version = 2\n");
+    assert!(!staging.exists());
+    Ok(())
+}
+```
+
+[`fs::rename`]: https://doc.rust-lang.org/std/fs/fn.rename.html

--- a/src/file/read-write/write-string.md
+++ b/src/file/read-write/write-string.md
@@ -1,0 +1,40 @@
+## Write a string to a file
+
+[![std-badge]][std] [![tempfile-badge]][tempfile] [![cat-filesystem-badge]][cat-filesystem]
+
+[`fs::write`] is the mirror of [`fs::read_to_string`]: it opens the path,
+writes the bytes, and closes the file in one call. The semantics are
+create-or-truncate — if the file exists, its previous contents are discarded;
+if it doesn't, it's created with default permissions.
+
+To append instead of replacing, build a [`File`] through [`OpenOptions`] with
+[`append`] set. To refuse to overwrite an existing file — useful when a stale
+file would be a bug — use [`create_new`] instead of `create`.
+
+```rust,edition2021
+use std::fs;
+use std::io;
+use tempfile::tempdir;
+
+fn main() -> io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("report.txt");
+
+    // Creates the file if missing.
+    fs::write(&path, "build ok\n")?;
+
+    // Calling write again replaces — does not append to — the previous contents.
+    fs::write(&path, "build ok\nemitted 12 warnings\n")?;
+
+    let back = fs::read_to_string(&path)?;
+    assert_eq!(back, "build ok\nemitted 12 warnings\n");
+    Ok(())
+}
+```
+
+[`File`]: https://doc.rust-lang.org/std/fs/struct.File.html
+[`OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+[`append`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append
+[`create_new`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new
+[`fs::read_to_string`]: https://doc.rust-lang.org/std/fs/fn.read_to_string.html
+[`fs::write`]: https://doc.rust-lang.org/std/fs/fn.write.html


### PR DESCRIPTION
fixes #793

## Summary

Adds five `std::path` and `std::fs` recipes that fill the gap before the existing `walkdir`/`glob` recipes — the operations most Rust programs need first.

**Read & Write** gains:
- Read a whole file into a string — [`fs::read_to_string`](https://doc.rust-lang.org/std/fs/fn.read_to_string.html), with a note on when to switch to [`BufReader`](https://doc.rust-lang.org/std/io/struct.BufReader.html)
- Write a string to a file — [`fs::write`](https://doc.rust-lang.org/std/fs/fn.write.html), create-or-truncate semantics; pointer to [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) for append
- Rename or atomically replace a file — [`fs::rename`](https://doc.rust-lang.org/std/fs/fn.rename.html), write-to-temp-then-rename pattern, cross-filesystem caveat

**Directory Traversal** gains:
- Construct and inspect a path — [`PathBuf`](https://doc.rust-lang.org/std/path/struct.PathBuf.html), [`push`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.push), [`with_extension`](https://doc.rust-lang.org/std/path/struct.Path.html#method.with_extension), [`with_file_name`](https://doc.rust-lang.org/std/path/struct.Path.html#method.with_file_name), [`file_name`](https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name)/[`file_stem`](https://doc.rust-lang.org/std/path/struct.Path.html#method.file_stem)/[`extension`](https://doc.rust-lang.org/std/path/struct.Path.html#method.extension)/[`parent`](https://doc.rust-lang.org/std/path/struct.Path.html#method.parent)
- Create a nested directory tree — [`fs::create_dir_all`](https://doc.rust-lang.org/std/fs/fn.create_dir_all.html) vs [`fs::create_dir`](https://doc.rust-lang.org/std/fs/fn.create_dir.html)

All examples use `std::path` and `std::fs`; `tempfile` (already a root dependency) keeps the filesystem-touching examples hermetic. No new crate dependencies.

## Test plan

- [x] `cargo test --test skeptic` — 184 passed
- [x] `cargo xtask test link` — 5032 OK
- [x] `./ci/spellcheck.sh list` — clean
- [x] `mdbook build` — no new warnings; anchors in `file.md` link to generated sections
- [ ] CI passes

<img width="820" height="808" alt="image" src="https://github.com/user-attachments/assets/4701153a-36fc-4545-a988-c01fe85576f2" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)